### PR TITLE
#95 Automation of FAPI Conformance Tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
+OPENID_GIT_URL=https://gitlab.com/openid/conformance-suite.git
+OPENID_GIT_TAG=${OPENID_GIT_TAG:-release-v4.1.4}
+
 KEYCLOAK_REALM=test
 KEYCLOAK_USER=admin
 KEYCLOAK_PASSWORD=admin
@@ -6,3 +9,7 @@ KEYCLOAK_FQDN=as.keycloak-fapi.org
 RESOURCE_FQDN=rs.keycloak-fapi.org
 CONFORMANCE_SUITE_FQDN=conformance-suite.keycloak-fapi.org
 
+AUTOMATE_TESTS=${AUTOMATE_TESTS:-true}
+KEYCLOAK_BASE_IMAGE=${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:11.0.1}
+KEYCLOAK_REALM_IMPORT_FILENAME=${KEYCLOAK_REALM_IMPORT_FILENAME:-realm.json}
+MVN_HOME=${MVN_HOME:-~/.m2}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,37 @@
 .bin
+
+HELP.md
+target/
+.mvn/
+mvnw
+mvnw.cmd
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+
+### VS Code ###
+.vscode/
+
+
+### Project-specific ###
+report/

--- a/README.md
+++ b/README.md
@@ -58,157 +58,81 @@ Who want to submit the output needs to send the pull-request to this repository.
 * [Docker Compose](https://docs.docker.com/compose/)
 * JDK and [Maven](https://maven.apache.org/)
 
-### Run FAPI Conformance suite server
+### Run FAPI Conformance suite, Keycloak server and Test Runner
 
-Clone [FAPI Conformance suite repository](https://gitlab.com/openid/conformance-suite) and move into the directory.
-
-```
-git clone https://gitlab.com/openid/conformance-suite.git
-cd conformance-suite
-```
-
-If you would like to run the server on Docker for Windows, add `volumes` for mongodb and use it in `docker-compose.yml` as follows. 
-
-```
-@@ -3,7 +3,7 @@ services:
-   mongodb:
-     image: mongo
-     volumes:
--     - ./mongo/data:/data/db
-+     - mongodata:/data/db
-   httpd:
-     build:
-       context: ./httpd
-@@ -36,3 +36,7 @@ services:
-       options:
-         max-size: "500k"
-         max-file: "5"
-+
-+volumes:
-+  mongodata:
-+
-```
-
-Then, build the server using Maven.
-
-```
-mvn clean package
-```
-
-Finally, boot all the containers using Docker Compose.
-
-```
-docker-compose up
-```
-
-### Run Local Keycloak server
-
-Clone [jsoss-sig/keycloak-fapi](https://github.com/jsoss-sig/keycloak-fapi) and move into the directory.
-
-```
-git clone https://github.com/jsoss-sig/keycloak-fapi.git
-cd keycloak-fapi
-```
+Edit `hosts` file as per the [Modify your hosts file](#Modify-your-hosts-file) section
 
 This repository contains default self-signed certificates for HTTPS, client private keys, Keycloak Realm JSON and FAPI Conformance suite config JSONs.
 If you would like to use the configurations as it is, you only need to build and boot all the containers using Docker Compose.
 
+Run the following command from the project basedir to start the test suite
+
 ```
-docker-compose up
+docker-compose up --build
 ```
+The OpenID FAPI Conformance test interface will then be reachable at [https://localhost:8443](https://localhost:8443).
+See instructions in [Run FAPI Conformance test plan](#Run-FAPI-Conformance-test-plan) 
+section for running the tests manually in your browser.
+
+To stop all containers after the automated tests have run:
+
+```
+docker-compose up --build --exit-code-from test_runner
+```
+
+The following options can be set as environment variables before the above command:
+
+* `KEYCLOAK_BASE_IMAGE` (default: quay.io/keycloak/keycloak:11.0.1)
+    * The keycloak image version used in the test suite
+* `KEYCLOAK_REALM_IMPORT_FILENAME` (default: realm.json)
+    * The keycloak realm import filename. Set this to `realm.json` if you are running the tests
+    against a local build of keycloak.
+* `AUTOMATE_TESTS` (default: true)
+    * Set to false to stop conformance-suite tests automatically running
+* `MVN_HOME` (default: ~/.m2)
+    * Set to use a custom maven home path
+* `OPENID_GIT_TAG` (default: release-v4.1.4)
+    * The OpenID Conformance Suite Git Tag to be cloned    
+
+
+**Example:**
+```
+KEYCLOAK_BASE_IMAGE=jboss/keycloak:6.0.1 docker-compose up --build
+```
+
+To stop and remove all containers, run the following:
+```
+docker stop $(docker ps -a -q)
+docker rm $(docker ps -a -q)
+```
+
+### Test Reports
+
+Once `test_runner` service has finished and exited, test reports will be copied to the 
+[./conformance-suite/report](./report) directory.
+
 
 ### Modify your `hosts` file
 
 To access to Keycloak and Resource server with FQDN, modify your `hosts` file in your local machine as follows.
 
 ```
-127.0.0.1 as.keycloak-fapi.org rs.keycloak-fapi.org
+127.0.0.1 as.keycloak-fapi.org rs.keycloak-fapi.org conformance-suite.keycloak-fapi.org
 ```
 
-### Run FAPI Conformance test plan
+### Run FAPI Conformance test plan manually
 
-1. Open https://localhost:8443
-2. Click `Create a new test plan` button.
-3. Choose `FAPI-RW-ID2 (and OpenBankingUK): Authorization server test (latest version)` as Test Plan.
-4. Choose `Client Authentication Type` you want to test.
-5. Choose `plain_fapi` as FAPI Profile.
-6. Choose `plain_response` as FAPI Response Mode.
-7. Click `JSON` tab and paste content of the configuration.
+1. Run this project with `AUTOMATE_TESTS=false` environment variable set
+2. Open https://conformance-suite.keycloak-fapi.org
+3. Click `Create a new test plan` button.
+4. Choose `FAPI-RW-ID2 (and OpenBankingUK): Authorization server test (latest version)` as Test Plan.
+5. Choose `Client Authentication Type` you want to test.
+6. Choose `plain_fapi` as FAPI Profile.
+7. Choose `plain_response` as FAPI Response Mode.
+8. Click `JSON` tab and paste content of the configuration.
   * If you want to use private_key_jwt client authentication, use [fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-PS256-PS256.json](./fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-PS256-PS256.json) or [fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-ES256-ES256.json](./fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-ES256-ES256.json).
   * If you want to use mtls client authentication, use [fapi-conformance-suite-configs/fapi-rw-id2-with-mtls-PS256-PS256.json](./fapi-conformance-suite-configs/fapi-rw-id2-with-mtls-PS256-PS256.json) or [fapi-conformance-suite-configs/fapi-rw-id2-with-mtls-ES256-ES256.json](./fapi-conformance-suite-configs/fapi-rw-id2-with-mtls-ES256-ES256.json).
-8. Click `Create Test Plan` button and follow the instructions. To proceed with the tests, You can authenticate using `john` account with password `john`. When rejecting authentication scenario, you can use `mike` account with password `mike`. In this case, you need to click `No` button to cancel the authentication in the consent screen.
-
-
-## How to deploy the servers on the internet
-
-If you would like to deploy on the internet, follow instructions below which use Amazon Linux 2 on Amazaon EC2 as an example.
-
-Install Docker.
-
-```
-sudo yum update -y
-sudo yum install -y docker
-sudo service docker start
-sudo usermod -a -G docker ec2-user
-```
-
-Install Docker Compose.
-
-```
-sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
-```
-
-Clone sources from GitHub.
-
-```
-git clone https://gitlab.com/openid/conformance-suite.git
-git clone https://github.com/jsoss-sig/keycloak-fapi.git
-```
-
-Export environment variables with the FQDN which you want to use.
-
-```
-export KEYCLOAK_FQDN=as.keycloak-fapi.org
-export RESOURCE_FQDN=rs.keycloak-fapi.org
-export CONFORMANCE_SUITE_FQDN=conformance-suite.keycloak-fapi.org
-```
-
-Modify `conformance-suite/docker-compose.xml` as follows.
-
-**Note: We need to set `fintechlabs.base_url` with public FQDN to change from `https://localhost:8443`** 
-
-```
-       context: ./server-dev
-     volumes:
-      - ./target/:/server/
--    command: java -jar /server/fapi-test-suite.jar --fintechlabs.devmode=true --fintechlabs.startredir=true
-+    command: java -jar /server/fapi-test-suite.jar --fintechlabs.devmode=true --fintechlabs.startredir=true --fintechlabs.base_url=https://${CONFORMANCE_SUITE_FQDN}
-     links:
-      - mongodb:mongodb
-      - microauth:microauth
-```
-
-Build FAPI Conformance suite server and boot the all containers using Docker Compose.
-
-```
-cd conformance-suite
-mvn clean package
-docker-compose up -d
-```
-
-Generate server certificates, Keycloak realm config and FAPI Conformance suite configs with your FQDN.
-
-```
-cd ../keycloak-fapi
-./setup-fqdn.sh
-```
-
-Boot the containers using Docker Compose.
-
-```
-docker-compose up -d
-```
+9. Click `Create Test Plan` button and follow the instructions. To proceed with the tests, You can authenticate using `john` account with password `john`. When rejecting authentication scenario, you can use `mike` account with password `mike`. In this case, you need to click `No` button to cancel the authentication in the consent screen.
 
 
 ## For Developers
@@ -221,7 +145,7 @@ Run `generate-all.sh` script simply to generate self-signed certificates for HTT
 ./generate-all.sh
 ```
 
-Now, you can boot a Keyclaok server with new configurations.
+Now, you can boot a Keycloak server with new configurations.
 
 ```
 docker-compose up --force-recreate
@@ -243,6 +167,50 @@ If you would like to run FAPI Conformance test against local built keycloak, mod
 ```
 
 It overrides the keycloak of the base image with the one built on the local machine.
+
+Then run the FAPI Conformance Suite with KEYCLOAK_REALM_IMPORT_FILENAME env var:
+
+```
+KEYCLOAK_REALM_IMPORT_FILENAME=realm-local.json docker-compose up --build
+```
+
+## Run FAPI Conformance test with persistent OpenID Server DB volume
+
+Running this test suite does not require a persistent storage volume for MongoDB. The main benefit of
+using persistent volume storage is that the OpenID Conformance Suite will remember the last test plan
+config you used, allowing for easier and faster manual test operation. If you wish to enable persistent volume storage for the MongoDB container, uncomment 
+the following lines in ./docker-compose.yml
+
+```
+...
+#    volumes:
+#     - mongodata:/data/db
+...
+#volumes:
+#  mongodata:
+```
+
+
+
+## Custom files in the conformance suite
+
+The conformance-suite folder within this repository is a local copy of OpenIds FAPI conformance suite (https://gitlab.com/openid/conformance-suite/).
+Incorporating the suite and running the conformance tests within docker-compose requires adding custom files into the base OpenId FAPI conformance suite.
+Below is a list of the custom files currently used by the base conformance-suite.
+* /conformance-suite/run-tests.sh
+  * Script for running / creating test plans
+* /conformance-suite/Dockerfile
+  * Dockerfile which installs python dependencies, exposes ports and kicks off building the project via the server-entrypoint script 
+* /conformance-suite/server-entrypoint.sh
+  * Script for building the project with maven
+* /conformance-suite/scripts/run-test-plan.py
+  * Existing file within the base conformance-suite repo that has been slightly modified to output test results to the file system.
+
+
+**Running different test plans**
+
+To create custom test plans, add code into /conformance-suite/run-tests.sh as per commented out examples.
+JSON configuration files for test plans should be created in /conformance-suite/.gitlab-ci/
 
 ## License
 

--- a/client_private_keys/Dockerfile
+++ b/client_private_keys/Dockerfile
@@ -10,6 +10,6 @@ FROM alpine:3.9
 
 # Install client-jwks-server for testing
 COPY --from=builder /go/src/github.com/soss-sig/keycloak-fapi/client-jwks-server /usr/local/sbin/
-
+ADD . /keys
 ENTRYPOINT [ "client-jwks-server" ]
 

--- a/conformance-suite/Dockerfile
+++ b/conformance-suite/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.6.3-openjdk-11-slim as builder
+ARG OPENID_GIT_URL
+ARG OPENID_GIT_TAG
+
+# the server app requires redir to run
+RUN apt-get update && apt-get install -y redir python3 python3-pip git
+RUN pip3 install requests
+RUN git clone -b ${OPENID_GIT_TAG} ${OPENID_GIT_URL} ./conformance-suite
+ADD . ./conformance-suite/
+EXPOSE 8080
+EXPOSE 9090
+CMD [ "sh", "./conformance-suite/server-entrypoint.sh" ]

--- a/conformance-suite/run-test-plan.py
+++ b/conformance-suite/run-test-plan.py
@@ -1,0 +1,1084 @@
+#!/usr/bin/env python3
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import re
+import sys
+import time
+import datetime
+import subprocess
+import fnmatch
+import pathlib
+import requests
+import json
+import argparse
+import traceback
+
+from conformance import Conformance
+
+# Modules list here are deliberately not run, as they have known problems
+ignored_modules = [
+    # see https://gitlab.com/openid/conformance-suite/-/issues/837
+    "oidcc-client-test-signing-key-rotation-just-before-signing",
+    "oidcc-client-test-signing-key-rotation"
+]
+
+# Wrapper that adds timestamps to the start of our output
+#
+# This is mainly useful when the test is running inside gitlab, so we can see what exact time each step happened at
+class timestamp_filter:
+    # pending_output stores any output passed to write where a \n has not yet been found
+    pending_output = ''
+    def write(self, message):
+        output = self.pending_output + message
+        (output, not_used, self.pending_output) =  output.rpartition('\n')
+        if output != '':
+            timestamp = time.strftime("%Y-%m-%d %X")
+            output = timestamp + " " + output.replace("\n", "\n"+timestamp+" ")
+            print(output, file=sys.__stdout__)
+            sys.__stdout__.flush()
+    def flush(self):
+        pass
+
+sys.stdout = timestamp_filter()
+
+def split_name_and_variant(test_plan):
+    if '[' in test_plan:
+        name = re.match(r'^[^\[]*', test_plan).group(0)
+        vs = re.finditer(r'\[([^=\]]*)=([^\]]*)\]', test_plan)
+        variant = { v.group(1) : v.group(2) for v in vs }
+        return (name, variant)
+    elif '(' in test_plan:
+        #only for oidcc RP tests
+        matches = re.match(r'(.*)\((.*)\)$', test_plan)
+        name = matches.group(1)
+        oidcc_configfile = matches.group(2)
+        return (name, oidcc_configfile)
+    else:
+        return (test_plan, None)
+
+#Run OIDCC RP tests
+#OIDCC RP tests use a configuration file instead of providing all options in run-tests.sh
+#this function runs plans in a loop and returns an array of results
+def run_test_plan_oidcc_rp(test_plan_name, config_file, json_config, oidcc_rptest_configfile, output_dir):
+    oidcc_test_config_json = []
+    with open(oidcc_rptest_configfile) as f:
+        oidcc_test_config = f.read()
+        oidcc_test_config_json = json.loads(oidcc_test_config)
+    all_plan_results = []
+    overall_starttime = time.time()
+
+    for test_plan_config in oidcc_test_config_json['tests']:
+        client_metadata_defaults = test_plan_config['client_metadata_defaults']
+        client_metadata_defaults_str = json.dumps(client_metadata_defaults)
+        other_environment_vars_for_script = {}
+        try:
+            if test_plan_config['other_environment_variables']:
+                other_environment_vars_for_script = test_plan_config['other_environment_variables']
+                del test_plan_config['other_environment_variables']
+        except:
+            pass
+        #remove client_metadata_defaults otherwise plan api call will fail
+        del test_plan_config['client_metadata_defaults']
+        test_plan_info = conformance.create_test_plan(test_plan_name, json_config, test_plan_config)
+
+        variantstr = json.dumps(test_plan_config)
+        print('VARIANT {}'.format(variantstr))
+
+        plan_id = test_plan_info['id']
+        plan_modules = test_plan_info['modules']
+        test_info = {}  # key is module name
+        test_time_taken = {}  # key is module_id
+        start_time_for_plan = time.time()
+        print('Created test plan, new id: {}'.format(plan_id))
+        print('{}plan-detail.html?plan={}'.format(api_url_base, plan_id))
+        print('{:d} modules to test:\n{}\n'.format(len(plan_modules), '\n'.join(mod['testModule'] for mod in plan_modules)))
+        for moduledict in plan_modules:
+            module=moduledict['testModule']
+            if module in ignored_modules:
+                continue
+            test_start_time = time.time()
+            module_id = ''
+            module_info = {}
+
+            try:
+                print('Running test module: {}'.format(module))
+                test_module_info = conformance.create_test_from_plan(plan_id, module)
+                module_id = test_module_info['id']
+                module_info['id'] = module_id
+                test_info[module] = module_info
+                print('Created test module, new id: {}'.format(module_id))
+                print('{}log-detail.html?log={}'.format(api_url_base, module_id))
+
+                state = conformance.wait_for_state(module_id, ["WAITING", "FINISHED"])
+
+                if state == "WAITING":
+                    oidcc_issuer_str = os.environ["CONFORMANCE_SERVER"] + os.environ["OIDCC_TEST_CONFIG_ALIAS"]
+                    print('ISSUER {}'.format(oidcc_issuer_str))
+                    print('CLIENT_METADATA_DEFAULTS {}'.format(client_metadata_defaults_str))
+
+                    os.putenv('CLIENT_METADATA_DEFAULTS', client_metadata_defaults_str)
+
+                    if other_environment_vars_for_script:
+                        for envvarname in other_environment_vars_for_script:
+                            os.putenv(envvarname, other_environment_vars_for_script[envvarname])
+                    os.putenv('VARIANT', variantstr)
+                    os.putenv('MODULE_NAME', module)
+                    os.putenv('ISSUER', oidcc_issuer_str)
+                    subprocess.call(["npm", "run", "client"], cwd="./sample-openid-client-nodejs")
+
+                    conformance.wait_for_state(module_id, ["FINISHED"])
+
+            except Exception as e:
+                traceback.print_exc()
+                print('Exception: Test {} failed to run to completion: {}'.format(module, e))
+            if module_id != '':
+                test_time_taken[module_id] = time.time() - test_start_time
+                module_info['info'] = conformance.get_module_info(module_id)
+                module_info['logs'] = conformance.get_test_log(module_id)
+
+        time_for_plan = time.time() - start_time_for_plan
+        print('Finished test plan - id: {} total time: {}'.format(plan_id, time_for_plan))
+        if output_dir != None:
+            start_time_for_save = time.time()
+            filename = conformance.exporthtml(plan_id, output_dir)
+            print('results saved to "{}" in {:.1f} seconds'.format(filename, time.time() - start_time_for_save))
+        print('\n\n')
+        result_for_plan = {
+            'test_plan': test_plan_name,
+            'config_file': config_file,
+            'plan_id': plan_id,
+            'plan_modules': plan_modules,
+            'test_info': test_info,
+            'test_time_taken': test_time_taken,
+            'overall_time': time_for_plan
+        }
+        all_plan_results.append(result_for_plan)
+
+    overall_time = time.time() - overall_starttime
+    print('--- Finished OIDCC RP tests. Total time: {} '.format(overall_time))
+    return all_plan_results
+
+# If testmodule has variants, return a string form like used on our command line
+# e.g.
+# oidcc-server[client_auth_type=client_secret_basic][response_mode=default][response_type=code]
+# This is useful for using as a dictionary key for storing results
+def get_string_name_for_module_with_variant(moduledict):
+    name = moduledict['testModule']
+    variants = moduledict.get('variant')
+    if variants != None:
+        for v in sorted(variants.keys()):
+            name += "[{}={}]".format(v, variants[v])
+    return name
+
+
+def run_test_plan(test_plan, config_file, output_dir):
+    print("Running plan '{}' with configuration file '{}'".format(test_plan, config_file))
+    with open(config_file) as f:
+        json_config = f.read()
+    (test_plan_name, variant) = split_name_and_variant(test_plan)
+    if test_plan_name.startswith('oidcc-client-'):
+        #for oidcc client tests 'variant' will contain the rp tests configuration file name
+        return run_test_plan_oidcc_rp(test_plan_name, config_file, json_config, variant, output_dir)
+    test_plan_info = conformance.create_test_plan(test_plan_name, json_config, variant)
+    plan_id = test_plan_info['id']
+    plan_modules = test_plan_info['modules']
+    test_info = {}  # key is module name
+    test_time_taken = {}  # key is module_id
+    overall_start_time = time.time()
+    print('Created test plan, new id: {}'.format(plan_id))
+    print('{}plan-detail.html?plan={}'.format(api_url_base, plan_id))
+    print('{:d} modules to test:\n{}\n'.format(len(plan_modules), '\n'.join(mod['testModule'] for mod in plan_modules)))
+    for moduledict in plan_modules:
+        module=moduledict['testModule']
+        module_with_variants = get_string_name_for_module_with_variant(moduledict)
+        test_start_time = time.time()
+        module_id = ''
+        module_info = {}
+
+        try:
+            print('Running test module: {}'.format(module_with_variants))
+            test_module_info = conformance.create_test_from_plan_with_variant(plan_id, module, moduledict.get('variant'))
+            module_id = test_module_info['id']
+            module_info['id'] = module_id
+            test_info[get_string_name_for_module_with_variant(moduledict)] = module_info
+            print('Created test module, new id: {}'.format(module_id))
+            print('{}log-detail.html?log={}'.format(api_url_base, module_id))
+
+            state = conformance.wait_for_state(module_id, ["CONFIGURED", "WAITING", "FINISHED"])
+            if state == "CONFIGURED":
+                if module == 'oidcc-server-rotate-keys':
+                    # This test needs manually started once the OP keys have been rotated; we can't actually do that
+                    # but at least we can run the test and check it finishes even if it always fails.
+                    print('Starting test')
+                    conformance.start_test(module_id)
+                state = conformance.wait_for_state(module_id, ["WAITING", "FINISHED"])
+
+            if state == "WAITING":
+                # If it's a client test, we need to run the client
+                if re.match(r'(fapi-rw-id2(-ob)?-client-.*)', module):
+                    profile = variant['fapi_profile']
+                    os.putenv('CLIENTTESTMODE', 'fapi-ob' if re.match(r'openbanking', profile) else 'fapi-rw')
+                    os.environ['ISSUER'] = os.environ["CONFORMANCE_SERVER"] + os.environ["TEST_CONFIG_ALIAS"]
+                    subprocess.call(["npm", "run", "client"], cwd="./sample-openbanking-client-nodejs")
+
+                conformance.wait_for_state(module_id, ["FINISHED"])
+
+        except Exception as e:
+            print('Exception: Test {} failed to run to completion: {}'.format(module_with_variants, e))
+        if module_id != '':
+            test_time_taken[module_id] = time.time() - test_start_time
+            module_info['info'] = conformance.get_module_info(module_id)
+            module_info['logs'] = conformance.get_test_log(module_id)
+    overall_time = time.time() - overall_start_time
+    if output_dir != None:
+        start_time_for_save = time.time()
+        filename = conformance.exporthtml(plan_id, output_dir)
+        print('results saved to "{}" in {:.1f} seconds'.format(filename, time.time() - start_time_for_save))
+    print('\n\n')
+    return {
+        'test_plan': test_plan,
+        'config_file': config_file,
+        'plan_id': plan_id,
+        'plan_modules': plan_modules,
+        'test_info': test_info,
+        'test_time_taken': test_time_taken,
+        'overall_time': overall_time
+    }
+
+
+# from http://stackoverflow.com/a/26445590/3191896 and https://gist.github.com/Jossef/0ee20314577925b4027f
+def color(text, **user_styles):
+
+    styles = {
+        # styles
+        'reset': '\033[0m',
+        'bold': '\033[01m',
+        'disabled': '\033[02m',
+        'underline': '\033[04m',
+        'reverse': '\033[07m',
+        'strike_through': '\033[09m',
+        'invisible': '\033[08m',
+        # text colors
+        'fg_black': '\033[30m',
+        'fg_red': '\033[31m',
+        'fg_green': '\033[32m',
+        'fg_orange': '\033[33m',
+        'fg_blue': '\033[34m',
+        'fg_purple': '\033[35m',
+        'fg_cyan': '\033[36m',
+        'fg_light_grey': '\033[37m',
+        'fg_dark_grey': '\033[90m',
+        'fg_light_red': '\033[91m',
+        'fg_light_green': '\033[92m',
+        'fg_yellow': '\033[93m',
+        'fg_light_blue': '\033[94m',
+        'fg_pink': '\033[95m',
+        'fg_light_cyan': '\033[96m',
+        # background colors
+        'bg_black': '\033[40m',
+        'bg_red': '\033[41m',
+        'bg_green': '\033[42m',
+        'bg_orange': '\033[43m',
+        'bg_blue': '\033[44m',
+        'bg_purple': '\033[45m',
+        'bg_cyan': '\033[46m',
+        'bg_light_grey': '\033[47m'
+    }
+
+    color_text = ''
+    for style in user_styles:
+        try:
+            color_text += styles[style]
+        except KeyError:
+            return 'def color: parameter {} does not exist'.format(style)
+    color_text += text
+    return '\033[0m{}\033[0m'.format(color_text)
+
+
+def redbg(text):
+    return color(text, bold=True, bg_red=True)
+
+def failure(text):
+    return color(text, bold=True, fg_red=True)
+
+
+def warning(text):
+    return color(text, bold=True, fg_orange=True)
+
+
+def success(text):
+    return color(text, fg_green=True)
+
+
+def expected_warning(text):
+    return color(text, fg_pink=True)
+
+
+def expected_failure(text):
+    return color(text, fg_light_cyan=True)
+
+
+def show_plan_results(plan_result, analyzed_result, report_path):
+    plan_id = plan_result['plan_id']
+    plan_modules = plan_result['plan_modules']
+    test_info = plan_result['test_info']
+    test_time_taken = plan_result['test_time_taken']
+    overall_time = plan_result['overall_time']
+    detail_plan_result = analyzed_result['detail_plan_result']
+
+    incomplete = 0
+    successful_conditions = 0
+    overall_test_results = list(detail_plan_result['overall_test_results'])
+
+    number_of_failures = 0
+    number_of_warnings = 0
+
+    counts_unexpected = detail_plan_result['counts_unexpected']
+
+    print('\n\nResults for {} with configuration {}:'.format(plan_result['test_plan'], plan_result['config_file']))
+    f = open(os.path.join(report_path, timeStamped('result-report.txt')), 'a')
+    for moduledict in plan_modules:
+        module_name = get_string_name_for_module_with_variant(moduledict)
+        if module_name in ignored_modules:
+            continue
+        if module_name not in test_info:
+            print(failure('Test {} did not run'.format(module_name)))
+            continue
+        module_info = test_info[module_name]
+        module_id = module_info['id']
+        info = module_info['info']
+        logs = module_info['logs']
+
+        status_coloured = info['status']
+
+        if info['status'] != 'FINISHED' and info['status'] != 'INTERRUPTED':
+            status_coloured = redbg(status_coloured)
+            incomplete += 1
+
+        test_name = info['testName']
+        result = overall_test_results.pop(0)['test_result']
+
+        if module_id in test_time_taken:
+            test_time = test_time_taken[module_id]
+        else:
+            test_time = -1
+        if info['result'] == 'PASSED':
+            result_coloured = success(info['result'])
+        elif info['result'] == 'WARNING':
+            result_coloured = warning(info['result'])
+        elif info['result'] == 'REVIEW':
+            result_coloured = color(info['result'], bold=True, fg_light_blue=True)
+        else:
+            result_coloured = failure(info['result'])
+
+        counts = result['counts']
+        print('Test {} {} {} - result {}. {:d} log entries - {:d} SUCCESS {:d} FAILURE, {:d} WARNING, {:.1f} seconds'.
+              format(module_name, module_id, status_coloured, result_coloured, len(logs),
+                     counts['SUCCESS'], counts['FAILURE'], counts['WARNING'], test_time))
+
+        f.write('Test {} {} {} - result {}. {:d} log entries - {:d} SUCCESS {:d} FAILURE, {:d} WARNING, {:.1f} seconds\n\n'.
+              format(module_name, module_id, info['status'], info['result'], len(logs),
+                     counts['SUCCESS'], counts['FAILURE'], counts['WARNING'], test_time))
+
+
+        summary_unexpected_failures_test_module(result, test_name, module_id)
+
+        successful_conditions += counts['SUCCESS']
+        number_of_failures += counts['FAILURE']
+        number_of_warnings += counts['WARNING']
+    f.close()
+    print(
+        '\nOverall totals: ran {:d} test modules. '
+        'Conditions: {:d} successes, {:d} failures, {:d} warnings. {:.1f} seconds'.
+        format(len(test_info), successful_conditions, number_of_failures, number_of_warnings, overall_time))
+    print('\n{}plan-detail.html?plan={}\n'.format(api_url_base, plan_id))
+
+    if len(test_info) != len(plan_modules):
+        print(failure("** NOT ALL TESTS FROM PLAN WERE RUN **"))
+        return
+
+    if incomplete != 0:
+        print(failure("** {:d} TEST MODULES DID NOT RUN TO COMPLETION **".format(incomplete)))
+        return
+
+    if counts_unexpected['UNEXPECTED_FAILURES'] > 0:
+        print(failure("** SOME TEST MODULES HAVE CONDITION UNEXPECTED FAILURES **"))
+
+    if  counts_unexpected['UNEXPECTED_WARNINGS'] > 0:
+        print(failure("** SOME TEST MODULES HAVE CONDITION UNEXPECTED WARNINGS **"))
+
+    if counts_unexpected['UNEXPECTED_SKIPS'] > 0:
+        print(failure("** SOME TEST MODULES WERE UNEXPECTEDLY SKIPPED **"))
+
+    if counts_unexpected['EXPECTED_FAILURES_NOT_HAPPEN'] > 0:
+        print(failure("** SOME TEST MODULES HAVE CONDITION EXPECTED FAILURE DID NOT HAPPEN **"))
+
+    if counts_unexpected['EXPECTED_WARNINGS_NOT_HAPPEN'] > 0:
+        print(failure("** SOME TEST MODULES HAVE CONDITION EXPECTED WARNING DID NOT HAPPEN **"))
+
+    if counts_unexpected['EXPECTED_SKIPS_NOT_HAPPEN'] > 0:
+        print(failure("** SOME TEST MODULES WERE EXPECTED TO BE SKIPPED BUT COMPLETED **"))
+
+
+# Returns object contains 'plan_did_not_complete' and 'detail_plan_result', ie.
+# 'plan_did_not_complete' = NOT_COMPLETE
+#     some test modules did not run complete
+# 'plan_did_not_complete' = FAILURE_OR_WARNING
+#     if any test unexpectedly failed to run to completion
+#     if any test was expected to be skipped but wasn't
+#     if condition failure/warning occurs and isn't listed in the config json file
+#     if failure/warning is expected and doesn't occur
+# 'plan_did_not_complete' = COMPLETE
+#     all test modules run complete
+def analyze_plan_results(plan_result, expected_failures_list, expected_skips_list):
+    plan_modules = plan_result['plan_modules']
+    test_info = plan_result['test_info']
+
+    incomplete = 0
+    overall_test_results = []
+    have_ignored_modules = False
+
+    counts_unexpected = {
+        'EXPECTED_FAILURES': 0,
+        'UNEXPECTED_FAILURES': 0,
+        'EXPECTED_FAILURES_NOT_HAPPEN': 0,
+        'EXPECTED_WARNINGS': 0,
+        'UNEXPECTED_WARNINGS': 0,
+        'EXPECTED_WARNINGS_NOT_HAPPEN': 0,
+        'EXPECTED_SKIPS': 0,
+        'UNEXPECTED_SKIPS': 0,
+        'EXPECTED_SKIPS_NOT_HAPPEN': 0
+    }
+
+    for moduledict in plan_modules:
+        module=moduledict['testModule']
+        if module in ignored_modules:
+            have_ignored_modules = True
+            continue
+        module_name_with_variant = get_string_name_for_module_with_variant(moduledict)
+        if module_name_with_variant not in test_info:
+            continue
+        module_info = test_info[module_name_with_variant]
+        module_id = module_info['id']
+        info = module_info['info']
+        logs = module_info['logs']
+
+        if module in untested_test_modules:
+            untested_test_modules.remove(module)
+
+        if info['status'] != 'FINISHED' and info['status'] != 'INTERRUPTED':
+            incomplete += 1
+        if 'result' not in info:
+            info['result'] = 'UNKNOWN'
+
+        test_name = info['testName']
+        result = analyze_result_logs(module_id, test_name, info['result'], plan_result, logs, expected_failures_list, expected_skips_list, counts_unexpected)
+
+        log_detail_link = '{}log-detail.html?log={}'.format(api_url_base, module_id)
+        test_result = {'test_name': test_name, 'log_detail_link': log_detail_link, 'test_result': result}
+        overall_test_results.append(test_result)
+
+    detail_plan_result = {
+        'plan_name': plan_result['test_plan'],
+        'plan_config_file': plan_result['config_file'],
+        'overall_test_results': overall_test_results,
+        'counts_unexpected': counts_unexpected
+    }
+
+    if (not have_ignored_modules and len(test_info) != len(plan_modules) or incomplete != 0):
+        return {'plan_did_not_complete': 'NOT_COMPLETE', 'detail_plan_result': detail_plan_result}
+    elif (counts_unexpected['UNEXPECTED_FAILURES']
+          or counts_unexpected['UNEXPECTED_WARNINGS']
+          or counts_unexpected['UNEXPECTED_SKIPS']
+          or counts_unexpected['EXPECTED_FAILURES_NOT_HAPPEN']
+          or counts_unexpected['EXPECTED_WARNINGS_NOT_HAPPEN']
+          or counts_unexpected['EXPECTED_SKIPS_NOT_HAPPEN']):
+        return {'plan_did_not_complete': 'FAILURE_OR_WARNING', 'detail_plan_result': detail_plan_result}
+    else:
+        return {'plan_did_not_complete': 'COMPLETE', 'detail_plan_result': detail_plan_result}
+
+
+# Analyze all log of a test module and return object contains:
+#   'expected_failures': list all expected failures condition
+#   'unexpected_failures': list all unexpected failures condition
+#   'expected_failures_did_not_happen': list all expected failures condition did not happen
+#   'expected_warnings': list all expected warnings condition
+#   'unexpected_warnings': list all unexpected warnings condition
+#   'expected_warnings_did_not_happen': list all expected warnings condition did not happen
+#   'counts': contains number of success condition, number of warning condition and number of failure condition
+def analyze_result_logs(module_id, test_name, test_result, plan_result, logs, expected_failures_list, expected_skips_list, counts_unexpected):
+    counts = {'SUCCESS': 0, 'WARNING': 0, 'FAILURE': 0}
+    expected_failures = []
+    unexpected_failures = []
+    expected_failures_did_not_happen = []
+
+    expected_warnings = []
+    unexpected_warnings = []
+    expected_warnings_did_not_happen = []
+
+    expected_skip = False
+    unexpected_skip = False
+    expected_skip_did_not_happen = False
+
+    test_plan = plan_result['test_plan']
+    config_filename = plan_result['config_file']
+    (test_plan_name, variant) = split_name_and_variant(test_plan)
+
+    def is_expected_for_this_test(obj):
+        """
+        Check if an expected failure/warning read from an 'expected' JSON file matches the current test module
+
+        The match is lose and allows the following:
+        - configuration-filename may contain shell-style wildcards (mainly '*')
+        - variant may be listed as a "*" to match all variants
+        - if variant is an object, only the keys/values listed in JSON will be checked (i.e. the entry will be assumed
+        to apply to all unlisted variants)
+
+        :param obj: expected_failure_obj entry from json expected list to test
+        :return: True if entry matches the current test module
+        """
+        if obj['test-name'] != test_name:
+            return False
+        if not fnmatch.fnmatch(config_filename, obj['configuration-filename']):
+            return False
+        expected_variant = obj.get('variant', None)
+        if expected_variant == "*":
+            return True
+        for k in expected_variant:
+            if not k in variant:
+                return False
+            if expected_variant[k] != variant[k]:
+                return False
+        return True
+
+    test_expected_failures = list(filter(is_expected_for_this_test, expected_failures_list))
+    test_expected_skips = list(filter(is_expected_for_this_test, expected_skips_list))
+
+    block_names = {}
+    block_msg = ''
+    for log_entry in logs:
+        if ('startBlock' in log_entry and log_entry['startBlock'] == True and log_entry['src'] == '-START-BLOCK-'):
+            block_names[log_entry['blockId']] = log_entry['msg']
+            continue
+        if 'result' not in log_entry:
+            continue
+
+        if ('blockId' in log_entry):
+            blockId = log_entry['blockId']
+            if blockId in block_names:
+                block_msg = block_names[blockId]
+            else:
+                # A new blockId was seen without a block start: this shouldn't happen.
+                # We don't have a sensible value for block_msg at this point, so log the error and stop analyzing this test.
+                print(failure('Unknown block ID in results: {}'.format(blockId)))
+                print('See {}log-detail.html?log={}'.format(api_url_base, module_id))
+                print('Log entry: {}'.format(log_entry))
+                break
+        else:
+            block_msg = ''
+
+        log_result = log_entry['result']  # contains WARNING/FAILURE/INFO/etc
+        if log_result in counts:
+            counts[log_result] += 1
+            log_entry_exist_in_expected_list = False
+            for expected_failure_obj in test_expected_failures:
+                expected_condition = expected_failure_obj['condition']
+                expected_block = expected_failure_obj['current-block']
+                expected_result = expected_failure_obj['expected-result']
+
+                if (expected_block == block_msg
+                    and expected_condition == log_entry['src']):
+
+                    # check and list all expected failure
+                    if (log_result == 'FAILURE' and expected_result == 'failure'):
+                        expected_failures.append({'current_block': block_msg, 'src': log_entry['src']})
+                        counts_unexpected['EXPECTED_FAILURES'] += 1
+
+                    # check and list all expected warning
+                    elif (log_result == 'WARNING' and expected_result == 'warning'):
+                        expected_warnings.append({'current_block': block_msg, 'src': log_entry['src']})
+                        counts_unexpected['EXPECTED_WARNINGS'] += 1
+
+                    # this wasn't an expected failure after all
+                    else:
+                        continue
+
+                    log_entry_exist_in_expected_list = True
+                    expected_failure_obj['__used'] = True
+                    break
+
+            # list all the unexpected failures/warnings of a test module
+            if log_entry_exist_in_expected_list == False:
+                if log_result == 'FAILURE':
+                    unexpected_failures.append({'current_block': block_msg, 'src': log_entry['src']})
+                    counts_unexpected['UNEXPECTED_FAILURES'] += 1
+
+                if log_result == 'WARNING':
+                    unexpected_warnings.append({'current_block': block_msg, 'src': log_entry['src']})
+                    counts_unexpected['UNEXPECTED_WARNINGS'] += 1
+
+    # list all the expected failures/warnings did not happen for a test module
+    for expected_failure_obj in test_expected_failures:
+        if '__used' in expected_failure_obj:
+            continue
+        expected_result = expected_failure_obj['expected-result']
+        expected_block = expected_failure_obj['current-block']
+        expected_condition = expected_failure_obj['condition']
+
+        if expected_result == 'failure':
+            expected_failures_did_not_happen.append({'current_block': expected_block, 'src': expected_condition})
+            counts_unexpected['EXPECTED_FAILURES_NOT_HAPPEN'] += 1
+
+        elif expected_result == 'warning':
+            expected_warnings_did_not_happen.append({'current_block': expected_block, 'src': expected_condition})
+            counts_unexpected['EXPECTED_WARNINGS_NOT_HAPPEN'] += 1
+
+    for expected_skip_obj in test_expected_skips:
+        if test_result == 'SKIPPED' or test_result == 'FAILED':
+            expected_skip = True
+            expected_skip_obj['__used'] = True
+        else:
+            expected_skip_did_not_happen = True
+            counts_unexpected['EXPECTED_SKIPS_NOT_HAPPEN'] += 1
+
+    if test_result == 'SKIPPED' and not expected_skip:
+        unexpected_skip = True
+        counts_unexpected['UNEXPECTED_SKIPS'] += 1
+
+    # currently the ob intent id match fails for authlete and we don't list it as a 'skip', so we can't check this
+    # this shouldn't matter much as all failed test results should have a 'FAILURE' log entry.
+    #if test_result == 'FAILED' and not expected_skip:
+    #    print(failure("Test result is FAILED: "+module_id))
+    #    counts_unexpected['UNEXPECTED_FAILURES'] += 1
+
+    if test_result != 'PASSED' and \
+        test_result != 'WARNING' and \
+        test_result != 'REVIEW' and \
+        test_result != 'SKIPPED' and \
+        test_result != 'FAILED':
+        print(failure("Test result is an unexpected value, "+test_result+" for: "+module_id))
+        counts_unexpected['UNEXPECTED_FAILURES'] += 1
+
+    return {
+        'expected_failures': expected_failures,
+        'unexpected_failures': unexpected_failures,
+        'expected_failures_did_not_happen': expected_failures_did_not_happen,
+        'expected_warnings': expected_warnings,
+        'unexpected_warnings': unexpected_warnings,
+        'expected_warnings_did_not_happen': expected_warnings_did_not_happen,
+        'expected_skip': expected_skip,
+        'unexpected_skip': unexpected_skip,
+        'expected_skip_did_not_happen': expected_skip_did_not_happen,
+        'counts': counts
+    }
+
+
+# Output all unexpected failure for each test module
+def summary_unexpected_failures_test_module(result, test_name, module_id):
+    expected_failures = result['expected_failures']
+    unexpected_failures = result['unexpected_failures']
+    expected_failures_did_not_happen = result['expected_failures_did_not_happen']
+
+    expected_warnings = result['expected_warnings']
+    unexpected_warnings = result['unexpected_warnings']
+    expected_warnings_did_not_happen = result['expected_warnings_did_not_happen']
+
+    expected_skip = result['expected_skip']
+    unexpected_skip = result['unexpected_skip']
+    expected_skip_did_not_happen = result['expected_skip_did_not_happen']
+
+    if len(expected_failures) > 0:
+        print(expected_failure("Expected failure: "))
+        print_failure_warning(expected_failures, 'failure', '\t', expected=True)
+
+    if len(unexpected_failures) > 0:
+        print(failure("Unexpected failure: "))
+        print_failure_warning(unexpected_failures, 'failure', '\t')
+
+    if len(expected_failures_did_not_happen) > 0:
+        print(failure("Expected failure did not happen: "))
+        print_failure_warning(expected_failures_did_not_happen, 'failure', '\t')
+
+    if len(expected_warnings) > 0:
+        print(expected_warning("Expected warning: "))
+        print_failure_warning(expected_warnings, 'warning', '\t', expected=True)
+
+    if len(unexpected_warnings) > 0:
+        print(warning("Unexpected warning: "))
+        print_failure_warning(unexpected_warnings, 'warning', '\t')
+
+    if len(expected_warnings_did_not_happen) > 0:
+        print(warning("Expected warning did not happen: "))
+        print_failure_warning(expected_warnings_did_not_happen, 'warning', '\t')
+
+    if expected_skip:
+        print(expected_warning("Test was skipped as expected"))
+
+    if unexpected_skip:
+        print(warning("Test was unexpectedly skipped"))
+
+    if expected_skip_did_not_happen:
+        print(warning("Test completed but was expected to be skipped"))
+
+
+# Output all unexpected failures for all test plan at the end of run-test-plan.py file
+def summary_unexpected_failures_all_test_plan(detail_plan_results):
+    for detail_plan_result in detail_plan_results:
+        if detail_plan_result:
+            config_filename = detail_plan_result['plan_config_file']
+            test_plan = detail_plan_result['plan_name']
+            print(failure('{} - {}: '.format(test_plan, config_filename)))
+            overall_test_results = detail_plan_result['overall_test_results']
+            counts_unexpected = detail_plan_result['counts_unexpected']
+            (test_plan_name, variant) = split_name_and_variant(test_plan)
+
+            if counts_unexpected['UNEXPECTED_FAILURES'] > 0:
+                print(failure('\tUnexpected failure: '))
+                output_summary_test_plan_by_unexpected_type(variant, config_filename, overall_test_results, 'unexpected_failures', 'failure')
+
+            if counts_unexpected['EXPECTED_FAILURES_NOT_HAPPEN'] > 0:
+                print(failure('\tExpected failure did not happen: '))
+                output_summary_test_plan_by_unexpected_type(variant, config_filename, overall_test_results, 'expected_failures_did_not_happen', 'failure')
+
+            if counts_unexpected['UNEXPECTED_WARNINGS'] > 0:
+                print(warning('\tUnexpected warning: '))
+                output_summary_test_plan_by_unexpected_type(variant, config_filename, overall_test_results, 'unexpected_warnings', 'warning')
+
+            if counts_unexpected['EXPECTED_WARNINGS_NOT_HAPPEN'] > 0:
+                print(warning('\tExpected warning did not happen: '))
+                output_summary_test_plan_by_unexpected_type(variant, config_filename, overall_test_results, 'expected_warnings_did_not_happen', 'warning')
+            if counts_unexpected['UNEXPECTED_SKIPS'] > 0:
+                print(warning('\tUnexpected skip: '))
+                output_summary_test_plan_by_unexpected_type(variant, config_filename, overall_test_results, 'unexpected_skip', 'warning')
+            if counts_unexpected['EXPECTED_SKIPS_NOT_HAPPEN'] > 0:
+                print(warning('\tExpected skip did not happen: '))
+                output_summary_test_plan_by_unexpected_type(variant, config_filename, overall_test_results, 'expected_skip_did_not_happen', 'warning')
+
+
+def output_summary_test_plan_by_unexpected_type(variant, config_filename, overall_test_results, key, unexpected_type):
+    for test_result in overall_test_results:
+        result = test_result['test_result']
+        if result[key]:
+            test_name = test_result['test_name']
+            header = '\t\t{} ({})'.format(test_name, test_result['log_detail_link'])
+            if 'skip' in key:
+                print(failure(header))
+                continue
+            if unexpected_type == 'failure':
+                print(failure(header))
+            else:
+                print(warning(header))
+            print_template = 'unexpected' in key
+            print_failure_warning(result[key], unexpected_type, '\t\t\t', variant=variant, config=config_filename, test=test_name, print_template=print_template)
+
+
+def print_failure_warning(failure_warning_list, status, tab_format, variant=None, expected=False, config=None, test=None, print_template=False):
+    for failure_warning in failure_warning_list:
+        msg = "{}Block name: '{}' - Condition: '{}'".format(tab_format,
+                                                            failure_warning['current_block'],
+                                                            failure_warning['src'])
+        template = {
+            'test-name': test,
+            'variant': variant,
+            'configuration-filename': config,
+            'current-block': failure_warning['current_block'],
+            'condition': failure_warning['src'],
+            'expected-result': status,
+            'comment': '**CHANGE ME** explain why this failure occurs'
+        }
+        if (status == 'failure'):
+            if expected:
+                print(expected_failure(msg))
+            else:
+                print(failure(msg))
+                if print_template:
+                    print("Template expected failure json:\n")
+                    # print json, skipping timestamp addition for easy C&P
+                    print(json.dumps(template, indent=4)+",\n", file=sys.__stdout__)
+        else:
+            if expected:
+                print(expected_warning(msg))
+            else:
+                print(warning(msg))
+                if print_template:
+                    print("Template expected warning json:\n")
+                    # print json, skipping timestamp addition for easy C&P
+                    print(json.dumps(template, indent=4)+",\n", file=sys.__stdout__)
+
+
+def load_expected_problems(filespec):
+    # read json config file which records a list of expected failures/warnings
+    all_loaded = []
+    for fname in filespec.split("|"):
+        with open(fname) as f:
+            data = f.read();
+            if data:
+                all_loaded.extend(json.loads(data))
+
+    # Check for duplicates
+    seen = []
+    duplicates = []
+    filtered = []
+    for item in all_loaded:
+        key = tuple(item.get(field, None) for field in ['test-name', 'variant', 'configuration-filename', 'condition', 'current-block'])
+        if key in seen:
+            duplicates.append(item)
+        else:
+            seen.append(key)
+            filtered.append(item)
+
+    if duplicates:
+        print(warning("** Some entries in the json is duplicated **"))
+        for entry in duplicates:
+            entry_duplicate_json = {
+                'test-name': entry['test-name'],
+                'variant': entry.get('variant', None),
+                'configuration-filename': entry['configuration-filename'],
+                'current-block': entry['current-block'],
+                'condition': entry['condition'],
+                'expected-result': entry['expected-result']
+            }
+            print(json.dumps(entry_duplicate_json, indent=4) + "\n", file=sys.__stdout__)
+
+    return filtered
+
+
+def parser_args_cli():
+    # Parser arguments list which is supplied by the user
+    parser = argparse.ArgumentParser(description='Parser arguments list which is supplied by the user')
+
+    parser.add_argument('--export-dir', help='Directory to save exported results into', default=None)
+    parser.add_argument('--show-untested-test-modules', help='Flag to require show or do not show test modules which were untested', default='')
+    parser.add_argument('--expected-failures-file', help='Json configuration file name which records a list of expected failures/warnings', default='')
+    parser.add_argument('--expected-skips-file', help='Json configuration file name which records a list of expected skipped tests', default='')
+    parser.add_argument('params', nargs='+', help='List parameters contains test-plan-name and configuration-file to run all test plan. Syntax: <test-plan-name> <configuration-file> ...')
+
+    return parser.parse_args()
+
+
+def timeStamped(fname, fmt='%Y-%m-%d-%H-%M_{fname}'):
+    return datetime.datetime.now().strftime(fmt).format(fname=fname)
+
+def get_test_report_path(subfolder):
+    parent_dir = "/conformance-suite/report/"
+    path = os.path.join(parent_dir, subfolder)
+    os.mkdir(path)
+    return path
+
+if __name__ == '__main__':
+    report_path = get_test_report_path(datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S'))
+
+    requests_session = requests.Session()
+
+    dev_mode = 'CONFORMANCE_DEV_MODE' in os.environ
+
+    if 'CONFORMANCE_SERVER' in os.environ:
+        api_url_base = os.environ['CONFORMANCE_SERVER']
+        if api_url_base == "":
+            print("Error: run-test-plan.py: CONFORMANCE_SERVER in environment seems to be empty")
+            sys.exit(1)
+        if not api_url_base.endswith('/'):
+            # make sure it ends in a / as the client tests assume that
+            api_url_base += '/'
+            os.environ['CONFORMANCE_SERVER'] = api_url_base
+    else:
+        # local development settings
+        api_url_base = 'https://localhost.emobix.co.uk:8443/'
+        dev_mode = True
+
+        os.environ["CONFORMANCE_SERVER"] = api_url_base
+
+    if dev_mode:
+        token = None
+    else:
+        token = os.environ['CONFORMANCE_TOKEN']
+
+    if dev_mode or 'DISABLE_SSL_VERIFY' in os.environ:
+        # disable https certificate validation
+        requests_session.verify = False
+        import urllib3
+
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    args = parser_args_cli()
+    show_untested = args.show_untested_test_modules
+    params = args.params
+
+    if len(params) % 2 == 1:
+        print("Error: run-test-plan.py: must have even number of parameters")
+        sys.exit(1)
+
+    to_run = []
+    while len(params) >= 2:
+        to_run.append((params[0], params[1]))
+        params = params[2:]
+
+    conformance = Conformance(api_url_base, token, requests_session)
+
+    for attempt in range(1, 12):
+        try:
+            all_test_modules_array = conformance.get_all_test_modules()
+            break
+        except Exception as exc:
+            # the server may not have finished starting yet; sleep & try again
+            print('Failed to connect to conformance suite on attempt {}: {}'.format(attempt, exc))
+            time.sleep(10)
+    else:
+        raise Exception("failed to connect to conformance suite")
+
+    # convert the array into a dictionary with the testName as the key
+    all_test_modules = {m['testName']: m for m in all_test_modules_array}
+    untested_test_modules = sorted(all_test_modules.keys())
+
+    expected_failures_list = []
+    if args.expected_failures_file:
+        expected_failures_list = load_expected_problems(args.expected_failures_file)
+
+    expected_skips_list = []
+    if args.expected_skips_file:
+        expected_skips_list = load_expected_problems(args.expected_skips_file)
+
+    results = []
+    for (plan_name, config_json) in to_run:
+        result = run_test_plan(plan_name, config_json, args.export_dir)
+        if isinstance(result, list):
+            results.extend(result)
+        else:
+            results.append(result)
+
+    print("\n\nScript complete - results:")
+
+    did_not_complete = False
+    failed_plan_results = []
+    for result in results:
+        plan_result = analyze_plan_results(result, expected_failures_list, expected_skips_list)
+        show_plan_results(result, plan_result, report_path)
+        plan_did_not_complete = plan_result['plan_did_not_complete']
+        if plan_did_not_complete == 'NOT_COMPLETE':
+            did_not_complete = True
+        elif plan_did_not_complete == 'FAILURE_OR_WARNING':
+            failed_plan_results.append(plan_result['detail_plan_result'])
+
+    if did_not_complete:
+        print(failure("** Exiting with failure - some tests did not run to completion **"))
+        sys.exit(1)
+
+    failed = False
+
+    # analyze_plan_results will remove expected failures and skips from the list, so if
+    # any remain at this point, they are unused and should be warned about.
+    def is_unused(obj):
+        return not '__used' in obj
+
+    unused_expected_failures = list(filter(is_unused, expected_failures_list))
+    if unused_expected_failures:
+        print(failure("** Exiting with failure - some expected failures were not found in any test module of the system **"))
+        f = open(os.path.join(report_path, timeStamped('failures-not-found.txt')), 'a')
+        for entry in unused_expected_failures:
+            entry_invalid_json = {
+                'test-name': entry['test-name'],
+                'variant': entry.get('variant', None),
+                'configuration-filename': entry['configuration-filename'],
+                'current-block': entry['current-block'],
+                'condition': entry['condition'],
+                'expected-result': entry['expected-result']
+            }
+            print(json.dumps(entry_invalid_json, indent=4) + "\n", file=sys.__stdout__)
+            f.write(json.dumps(entry_invalid_json, indent=4) + "\n\n")
+        failed = True
+        f.close()
+
+    unused_expected_skips = list(filter(is_unused, expected_skips_list))
+    if unused_expected_skips:
+        print(failure("** Exiting with failure - some expected skips were not found in any test module of the system **"))
+        f = open(os.path.join(report_path, timeStamped('expected-skips-not-found.txt')), 'a')
+        for entry in unused_expected_skips:
+            entry_invalid_json = {
+                'test-name': entry['test-name'],
+                'variant': entry.get('variant', None),
+                'configuration-filename': entry['configuration-filename']
+            }
+            print(json.dumps(entry_invalid_json, indent=4) + "\n", file=sys.__stdout__)
+            f.write(json.dumps(entry_invalid_json, indent=4) + "\n\n")
+        failed = True
+        f.close()
+
+    if failed_plan_results:
+        summary_unexpected_failures_all_test_plan(failed_plan_results)
+        print(failure("** Exiting with failure - some test modules have unexpected condition failures/warnings **"))
+        failed = True
+
+    # filter untested list, as we don't currently have test environments for these
+    for m in untested_test_modules[:]:
+        if m in ignored_modules:
+            untested_test_modules.remove(m)
+            continue
+
+        if all_test_modules[m]['profile'] in ['HEART']:
+            untested_test_modules.remove(m)
+            continue
+
+        if re.match(r'(oidcc-session-management-.*)', m):
+            # The browser automation currently doesn't seem to work for the iframes/js these tests use
+            untested_test_modules.remove(m)
+            continue
+
+        if m in ["oidcc-client-test-request-uri-signed-none", "oidcc-client-test-request-uri-signed-rs256"]:
+            # It seems these are not currently tested by the CI; see:
+            # https://gitlab.com/openid/conformance-suite/-/issues/840
+            untested_test_modules.remove(m)
+            continue
+
+        #we don't have automated tests for OIDCC RP login/logout tests
+        if re.match(r'(oidcc-client-test-.*logout.*)',m) or m == 'oidcc-client-test-session-management'\
+            or m == 'oidcc-client-test-3rd-party-init-login':
+            untested_test_modules.remove(m)
+            continue
+
+        if show_untested == 'client':
+            # Only run client test, therefore ignore all server test
+            if not ( re.match(r'(fapi-rw-id2-client-.*)', m) or re.match(r'(fapi-rw-id2-ob-client-.*)', m)  or re.match(r'(oidcc-client-.*)', m) ):
+                untested_test_modules.remove(m)
+                continue
+        elif show_untested == 'server-oidc-provider':
+            # Only run server test, ignore all client/CIBA test, plus we don't run the FAPI tests against oidc provider
+            if re.match(r'(fapi-.*)', m) or re.match(r'(oidcc-client-.*)', m):
+                untested_test_modules.remove(m)
+                continue
+        elif show_untested == 'server-authlete':
+            # ignore all client/CIBA test, plus we don't run the rp initiated logout tests against Authlete
+            if re.match(r'(fapi-rw-id2-client-.*)', m) or re.match(r'(fapi-ciba-id1.*)', m) or re.match(r'(oidcc-client-.*)', m) or re.match(r'(oidcc-.*-logout.*)', m):
+                untested_test_modules.remove(m)
+                continue
+        elif show_untested == 'all-except-logout':
+            # we don't run the rp initiated logout tests against Authlete
+            if re.match(r'(oidcc-.*-logout.*)', m):
+                untested_test_modules.remove(m)
+                continue
+        elif show_untested == 'ciba':
+            # Only run server test, therefore ignore all ciba test
+            if not re.match(r'(fapi-ciba-id1.*)', m):
+                untested_test_modules.remove(m)
+                continue
+
+    if show_untested and len(untested_test_modules) > 0:
+        print(failure("** Exiting with failure - not all available modules were tested:"))
+        f = open(os.path.join(report_path, timeStamped('modules-untested.txt')), 'a')
+        for m in untested_test_modules:
+            print('{}: {}'.format(all_test_modules[m]['profile'], m))
+            f.write('{}: {}\n\n'.format(all_test_modules[m]['profile'], m))
+        failed = True
+        f.close()
+
+    # wait a bit before exiting so that end of output isn't lost - https://gitlab.com/gitlab-org/gitlab/-/issues/217199
+    time.sleep(20)
+
+    if failed:
+        sys.exit(1)
+
+    print(success("All tests ran to completion. See above for any test condition failures."))
+    sys.exit(0)

--- a/conformance-suite/run-tests.sh
+++ b/conformance-suite/run-tests.sh
@@ -1,0 +1,290 @@
+#!/bin/sh
+
+set -e
+cleanup() {
+    echo
+    echo
+    echo "`date '+%Y-%m-%d %H:%M:%S'`: run-tests.sh exiting"
+    echo
+    echo
+}
+trap cleanup EXIT
+
+echo
+echo
+echo "`date '+%Y-%m-%d %H:%M:%S'`: run-tests.sh starting"
+echo
+echo
+
+# to run tests against a cloud environment, you need to:
+# 1. create an API token
+# 2. set the CONFORMANCE_TOKEN environment variable to the token
+# 3. do "source demo-environ.sh" (or whichever environment you want to run against)
+# (to run against your local deployment, just don't do the 'source' command)
+
+export TEST_CONFIG_ALIAS='test/a/fintech-clienttest/'
+export OIDCC_TEST_CONFIG_ALIAS='test/a/openidfoundationinternal-clienttest/'
+export ACCOUNTS='test-mtls/a/fintech-clienttest/open-banking/v1.1/accounts'
+export ACCOUNT_REQUEST='test/a/fintech-clienttest/open-banking/v1.1/account-requests'
+
+TESTS=""
+EXPECTED_FAILURES_FILE="../conformance-suite/.gitlab-ci/expected-failures-server.json|../conformance-suite/.gitlab-ci/expected-failures-ciba.json|../conformance-suite/.gitlab-ci/expected-failures-client.json"
+EXPECTED_SKIPS_FILE="../conformance-suite/.gitlab-ci/expected-skips-server.json|../conformance-suite/.gitlab-ci/expected-skips-ciba.json|../conformance-suite/.gitlab-ci/expected-skips-client.json"
+
+makeClientTest() {
+    . node-client-setup.sh
+    . node-core-client-setup.sh
+
+    # client FAPI-RW-ID2
+    TESTS="${TESTS} fapi-rw-id2-client-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi] automated-ob-client-test.json"
+    TESTS="${TESTS} fapi-rw-id2-client-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi] automated-ob-client-test.json"
+
+    # client FAPI-RW-ID2-OB
+    TESTS="${TESTS} fapi-rw-id2-client-test-plan[client_auth_type=private_key_jwt][fapi_profile=openbanking_uk] automated-ob-client-test.json"
+    TESTS="${TESTS} fapi-rw-id2-client-test-plan[client_auth_type=mtls][fapi_profile=openbanking_uk] automated-ob-client-test.json"
+
+	# client OpenID Connect Core Client Tests
+    TESTS="${TESTS} oidcc-client-test-plan(../conformance-suite/.gitlab-ci/oidcc-rp-tests-config.json) automated-oidcc-client-test.json"
+    # OIDC Core RP refresh token tests
+    TESTS="${TESTS} oidcc-client-refreshtoken-test-plan(../conformance-suite/.gitlab-ci/oidcc-rp-refreshtoken-test-plan-config.json) automated-oidcc-client-test.json"
+}
+
+makeServerTest() {
+    # OIDCC certification tests - static server, static client configuration
+#    TESTS="${TESTS} oidcc-basic-certification-test-plan[server_metadata=static][client_registration=static_client] authlete-oidcc-secret-basic-server-static.json"
+#    TESTS="${TESTS} oidcc-implicit-certification-test-plan[server_metadata=static][client_registration=static_client] authlete-oidcc-secret-basic-server-static.json"
+#    TESTS="${TESTS} oidcc-hybrid-certification-test-plan[server_metadata=static][client_registration=static_client] authlete-oidcc-secret-basic-server-static.json"
+#    TESTS="${TESTS} oidcc-formpost-basic-certification-test-plan[server_metadata=static][client_registration=static_client] authlete-oidcc-secret-basic-server-static.json"
+#    TESTS="${TESTS} oidcc-formpost-implicit-certification-test-plan[server_metadata=static][client_registration=static_client] authlete-oidcc-secret-basic-server-static.json"
+#    TESTS="${TESTS} oidcc-formpost-hybrid-certification-test-plan[server_metadata=static][client_registration=static_client] authlete-oidcc-secret-basic-server-static.json"
+
+    # OIDCC certification tests - server supports discovery, static client
+#    TESTS="${TESTS} oidcc-basic-certification-test-plan[server_metadata=discovery][client_registration=static_client] authlete-oidcc-secret-basic.json"
+#    TESTS="${TESTS} oidcc-implicit-certification-test-plan[server_metadata=discovery][client_registration=static_client] authlete-oidcc-secret-basic.json"
+#    TESTS="${TESTS} oidcc-hybrid-certification-test-plan[server_metadata=discovery][client_registration=static_client] authlete-oidcc-secret-basic.json"
+#    TESTS="${TESTS} oidcc-config-certification-test-plan authlete-oidcc-secret-basic.json"
+#    TESTS="${TESTS} oidcc-formpost-basic-certification-test-plan[server_metadata=discovery][client_registration=static_client] authlete-oidcc-secret-basic.json"
+#    TESTS="${TESTS} oidcc-formpost-implicit-certification-test-plan[server_metadata=discovery][client_registration=static_client] authlete-oidcc-secret-basic.json"
+#    TESTS="${TESTS} oidcc-formpost-hybrid-certification-test-plan[server_metadata=discovery][client_registration=static_client] authlete-oidcc-secret-basic.json"
+#
+#    # OIDCC certification tests - server supports discovery, using dcr
+#    TESTS="${TESTS} oidcc-basic-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+#    TESTS="${TESTS} oidcc-implicit-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+#    TESTS="${TESTS} oidcc-hybrid-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+#    TESTS="${TESTS} oidcc-config-certification-test-plan authlete-oidcc-dcr.json"
+#    TESTS="${TESTS} oidcc-dynamic-certification-test-plan[response_type=code\ id_token] authlete-oidcc-dcr.json"
+#    TESTS="${TESTS} oidcc-formpost-basic-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+#    TESTS="${TESTS} oidcc-formpost-implicit-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+#    TESTS="${TESTS} oidcc-formpost-hybrid-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+
+    # OIDCC
+    # commented out tests removed as they don't test something significantly different, in order to keep the test time down
+    # client_secret_basic - static client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code][response_mode=default][client_registration=static_client] authlete-oidcc-secret-basic.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ id_token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-basic.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-basic.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-basic.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=id_token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-basic.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-basic.json"
+
+    # client_secret_basic - dynamic client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+
+    # client_secret_post - static client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code][response_mode=default][client_registration=static_client] authlete-oidcc-secret-post.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ id_token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-post.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-post.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-post.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=id_token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-post.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-post.json"
+
+    # client_secret_post - dynamic client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+
+    # client_secret_jwt - static client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code][response_mode=default][client_registration=static_client] authlete-oidcc-secret-jwt.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ id_token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-jwt.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-jwt.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-jwt.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=id_token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-jwt.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-secret-jwt.json"
+
+    # client_secret_jwt - dynamic client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+
+    # private_key_jwt - static client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code][response_mode=default][client_registration=static_client] authlete-oidcc-privatekey.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ id_token][response_mode=default][client_registration=static_client] authlete-oidcc-privatekey.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ token][response_mode=default][client_registration=static_client] authlete-oidcc-privatekey.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-privatekey.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=id_token][response_mode=default][client_registration=static_client] authlete-oidcc-privatekey.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=id_token\ token][response_mode=default][client_registration=static_client] authlete-oidcc-privatekey.json"
+
+    # private_key_jwt - dynamic client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=id_token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+
+    # form post
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ id_token][response_mode=form_post][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ id_token\ token][response_mode=form_post][client_registration=dynamic_client] authlete-oidcc-dcr.json"
+
+
+    # authlete openbanking
+#    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=mtls][fapi_profile=openbanking_uk][fapi_response_mode=plain_response] authlete-fapi-rw-id2-ob-mtls.json"
+#    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=private_key_jwt][fapi_profile=openbanking_uk][fapi_response_mode=plain_response] authlete-fapi-rw-id2-ob-privatekey.json"
+
+    # authlete FAPI
+#    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][fapi_response_mode=plain_response] authlete-fapi-rw-id2-mtls.json"
+#    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][fapi_response_mode=plain_response] authlete-fapi-rw-id2-privatekey.json"
+#    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][fapi_response_mode=jarm] authlete-fapi-rw-id2-mtls-jarm.json"
+#    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][fapi_response_mode=jarm] authlete-fapi-rw-id2-privatekey-jarm.json"
+#    TESTS="${TESTS} fapi-r-test-plan[fapir_client_auth_type=mtls] authlete-fapi-r-mtls.json"
+#    TESTS="${TESTS} fapi-r-test-plan[fapir_client_auth_type=private_key_jwt] authlete-fapi-r-private-key.json"
+#    TESTS="${TESTS} fapi-r-test-plan[fapir_client_auth_type=client_secret_jwt] authlete-fapi-r-client-secret.json"
+#    TESTS="${TESTS} fapi-r-test-plan[fapir_client_auth_type=none] authlete-fapi-r-pkce.json"
+
+    # This is the configuration used in the instructions as an example.
+    # We keep it here as we want to be sure code changes don't break the example in the instructions, but the downside is there
+    # is a chance that users may be using the alias at the same time our tests are running
+#    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][fapi_response_mode=plain_response] authlete-fapi-rw-id2-privatekey-for-instructions.json"
+    TESTS="${TESTS} fapi-rw-id2-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][fapi_response_mode=plain_response][fapi_auth_request_method=by_value] ../conformance-suite/.gitlab-ci/fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-PS256-PS256-automated.json"
+}
+
+makeCIBATest() {
+    # ciba
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][ciba_mode=poll][client_registration=static_client] authlete-fapi-ciba-id1-mtls-poll.json"
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][ciba_mode=poll][client_registration=static_client] authlete-fapi-ciba-id1-privatekey-poll.json"
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=mtls][fapi_profile=openbanking_uk][ciba_mode=poll][client_registration=static_client] authlete-fapi-ciba-id1-mtls-poll.json"
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=private_key_jwt][fapi_profile=openbanking_uk][ciba_mode=poll][client_registration=static_client] authlete-fapi-ciba-id1-privatekey-poll.json"
+
+    # ciba poll DCR
+    #TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][ciba_mode=poll][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][ciba_mode=poll][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=mtls][fapi_profile=openbanking_uk][ciba_mode=poll][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+    #TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=private_key_jwt][fapi_profile=openbanking_uk][ciba_mode=poll][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+
+    # ciba ping DCR
+    # only one backchannel notification endpoint is allowed in CIBA so DCR must be used for ping testing
+    # see https://gitlab.com/openid/conformance-suite/issues/389
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=mtls][fapi_profile=plain_fapi][ciba_mode=ping][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+    #TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=private_key_jwt][fapi_profile=plain_fapi][ciba_mode=ping][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+    #TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=mtls][fapi_profile=openbanking_uk][ciba_mode=ping][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+    TESTS="${TESTS} fapi-ciba-id1-test-plan[client_auth_type=private_key_jwt][fapi_profile=openbanking_uk][ciba_mode=ping][client_registration=dynamic_client] authlete-fapi-ciba-id1-dcr.json"
+    # push isn't allowed in FAPI-CIBA profile
+    #TESTS="${TESTS} fapi-ciba-id1-push-with-mtls-test-plan authlete-fapi-ciba-id1-mtls-push.json"
+}
+
+makeLocalProviderTests() {
+    # OIDCC certification tests - server supports discovery, using dcr
+    TESTS="${TESTS} oidcc-basic-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-implicit-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-hybrid-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-config-certification-test-plan ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-dynamic-certification-test-plan[response_type=code\ id_token] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-formpost-basic-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-formpost-implicit-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-formpost-hybrid-certification-test-plan[server_metadata=discovery][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+
+    # OIDCC
+    # client_secret_basic - dynamic client
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_basic][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+
+    # client_secret_post - dynamic client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+
+    # client_secret_jwt - dynamic client
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+
+    # private_key_jwt - dynamic client
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    #TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=code\ id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=id_token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=private_key_jwt][response_type=id_token\ token][response_mode=default][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+
+    # form post
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_post][response_type=code\ id_token][response_mode=form_post][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+    TESTS="${TESTS} oidcc-test-plan[client_auth_type=client_secret_jwt][response_type=code][response_mode=form_post][client_registration=dynamic_client] ../conformance-suite/.gitlab-ci/local-provider-oidcc.plan"
+
+}
+
+if [ "$#" -eq 0 ]; then
+    TESTS="${TESTS} --expected-failures-file ${EXPECTED_FAILURES_FILE}"
+    TESTS="${TESTS} --expected-skips-file ${EXPECTED_SKIPS_FILE}"
+    TESTS="${TESTS} --show-untested-test-modules all"
+    echo "Run all tests"
+    makeServerTest
+    makeCIBATest
+    makeClientTest
+elif [ "$#" -eq 1 ] && [ "$1" = "--client-tests-only" ]; then
+    EXPECTED_FAILURES_FILE="../conformance-suite/.gitlab-ci/expected-failures-client.json"
+    EXPECTED_SKIPS_FILE="../conformance-suite/.gitlab-ci/expected-skips-client.json"
+    TESTS="${TESTS} --expected-failures-file ${EXPECTED_FAILURES_FILE}"
+    TESTS="${TESTS} --expected-skips-file ${EXPECTED_SKIPS_FILE}"
+    TESTS="${TESTS} --show-untested-test-modules client"
+    echo "Run client tests"
+    makeClientTest
+elif [ "$#" -eq 1 ] && [ "$1" = "--server-tests-only" ]; then
+#    EXPECTED_FAILURES_FILE="../conformance-suite/.gitlab-ci/expected-failures-server.json"
+#    EXPECTED_SKIPS_FILE="../conformance-suite/.gitlab-ci/expected-skips-server.json"
+#    TESTS="${TESTS} --expected-failures-file ${EXPECTED_FAILURES_FILE}"
+#    TESTS="${TESTS} --expected-skips-file ${EXPECTED_SKIPS_FILE}"
+#    TESTS="${TESTS} --show-untested-test-modules server"
+    echo "Run server tests"
+    makeServerTest
+elif [ "$#" -eq 1 ] && [ "$1" = "--ciba-tests-only" ]; then
+    EXPECTED_FAILURES_FILE="../conformance-suite/.gitlab-ci/expected-failures-ciba.json"
+    EXPECTED_SKIPS_FILE="../conformance-suite/.gitlab-ci/expected-skips-ciba.json"
+    TESTS="${TESTS} --expected-failures-file ${EXPECTED_FAILURES_FILE}"
+    TESTS="${TESTS} --expected-skips-file ${EXPECTED_SKIPS_FILE}"
+    TESTS="${TESTS} --show-untested-test-modules ciba"
+    echo "Run ciba tests"
+    makeCIBATest
+elif [ "$#" -eq 1 ] && [ "$1" = "--local-provider-tests" ]; then
+    EXPECTED_FAILURES_FILE="../conformance-suite/.gitlab-ci/expected-failures-local.json"
+    EXPECTED_SKIPS_FILE="../conformance-suite/.gitlab-ci/expected-skips-local.json"
+    TESTS="${TESTS} --expected-failures-file ${EXPECTED_FAILURES_FILE}"
+    TESTS="${TESTS} --expected-skips-file ${EXPECTED_SKIPS_FILE}"
+    echo "Run local provider tests"
+    makeLocalProviderTests
+else
+    echo "Syntax: run-tests.sh [--client-tests-only|--server-tests-only|--ciba-tests-only|--local-provider-tests]"
+    exit 1
+fi
+
+echo ${TESTS} | xargs /conformance-suite/scripts/run-test-plan.py

--- a/conformance-suite/server-entrypoint.sh
+++ b/conformance-suite/server-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+cd conformance-suite
+mv -f run-tests.sh ./.gitlab-ci
+mv -f run-test-plan.py ./scripts
+mvn package -DskipTests
+java -Xdebug -Xrunjdwp:transport=dt_socket,address=*:9999,server=y,suspend=n \
+    -jar target/fapi-test-suite.jar \
+    -Djava.security.egd=file:/dev/./urandom \
+    --fintechlabs.base_url=${CONFORMANCE_SERVER} \
+    --fintechlabs.devmode=true \
+    --fintechlabs.startredir=true \
+    --logging.level.net.openid.conformance.frontChannel=DEBUG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.6'
 services:
   load_balancer:
     build:
@@ -12,28 +12,29 @@ services:
     depends_on:
      - keycloak
      - api_gateway_nginx
+     - httpd
     networks:
       default:
         aliases:
          - ${KEYCLOAK_FQDN}
          - ${RESOURCE_FQDN}
-      conformance-suite_default:
-        aliases:
-         - ${KEYCLOAK_FQDN}
-         - ${RESOURCE_FQDN}
+         - ${CONFORMANCE_SUITE_FQDN}
   keycloak:
     build:
       context: ./keycloak
-    volumes:
-     - ./https/server.pem:/etc/x509/https/tls.crt
-     - ./https/server-key.pem:/etc/x509/https/tls.key
-     - ./https/client-ca.pem:/etc/x509/https/client-ca.crt
-#     - ../bin/keycloak-conformance-test:/opt/jboss/keycloak
+      args:
+        KEYCLOAK_BASE_IMAGE: ${KEYCLOAK_BASE_IMAGE}
+        KEYCLOAK_REALM_IMPORT_FILENAME: ${KEYCLOAK_REALM_IMPORT_FILENAME}
     ports:
      - "8787:8787"
     environment:
      - KEYCLOAK_USER=${KEYCLOAK_USER}
      - KEYCLOAK_PASSWORD=${KEYCLOAK_PASSWORD}
+    volumes:
+     - ./https/server.pem:/etc/x509/https/tls.crt
+     - ./https/server-key.pem:/etc/x509/https/tls.key
+     - ./https/client-ca.pem:/etc/x509/https/client-ca.crt
+#     - ../bin/keycloak-conformance-test:/opt/jboss/keycloak
     command: "-b 0.0.0.0 -Djboss.socket.binding.port-offset=1000 --debug -Dkeycloak.profile=preview"
   api_gateway_nginx:
     build:
@@ -51,6 +52,7 @@ services:
      - CLIENT_SECRET=2ef90464-b0fc-4e06-965d-19ef671a3e22
     depends_on:
      - resource_server
+     - keycloak
   resource_server:
     build:
       context: ./resource-server
@@ -58,10 +60,57 @@ services:
     build:
       context: ./client_private_keys
     volumes:
-     - ./client_private_keys:/keys
+      - ./client_private_keys:/keys
     command: /keys
-
-networks:
-  conformance-suite_default:
-    external: true
-
+  test_runner:
+    build:
+      context: ./test-runner
+    environment:
+     - AUTOMATE_TESTS=${AUTOMATE_TESTS}
+    volumes:
+     - /var/run/docker.sock:/var/run/docker.sock
+     - ./fapi-conformance-suite-configs:/json-config
+    depends_on:
+     - load_balancer
+     - keycloak
+     - server
+  mongodb:
+    image: mongo
+#    volumes:
+#     - mongodata:/data/db
+  httpd:
+    build:
+      context: ${OPENID_GIT_URL}#${OPENID_GIT_TAG}:httpd
+    ports:
+      - "8443:8443"
+    depends_on:
+      - server
+  server:
+    build:
+      context: ./conformance-suite
+      args:
+        OPENID_GIT_URL: ${OPENID_GIT_URL}
+        OPENID_GIT_TAG: ${OPENID_GIT_TAG}
+    ports:
+      - "9999:9999"
+    volumes:
+      - ${MVN_HOME}:/root/.m2
+      - ./report:/conformance-suite/report
+      - ./fapi-conformance-suite-configs/:/conformance-suite/.gitlab-ci/fapi-conformance-suite-configs/
+    environment:
+      - CONFORMANCE_SERVER=https://${CONFORMANCE_SUITE_FQDN}
+      - CONFORMANCE_DEV_MODE=1
+      - MONGODB_HOST=mongodb
+    links:
+      - mongodb:mongodb
+    depends_on:
+      - mongodb
+      - keycloak
+    logging:
+      # limit logs retained on host
+      driver: "json-file"
+      options:
+        max-size: "500k"
+        max-file: "5"
+#volumes:
+#  mongodata:

--- a/fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-PS256-PS256-automated.json
+++ b/fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-PS256-PS256-automated.json
@@ -1,0 +1,956 @@
+{
+    "alias": "keycloak",
+    "description": "FAPI-RW-ID2: Keycloak test with private_key_jwt client authentication (RequestObject:PS256/IDToken:PS256)",
+    "server": {
+        "discoveryUrl": "https://as.keycloak-fapi.org/auth/realms/test/.well-known/openid-configuration"
+    },
+    "client": {
+        "client_id": "client1-private_key_jwt-PS256-PS256",
+        "scope": "openid email",
+        "jwks": {
+            "keys": [
+                {
+                    "use": "sig",
+                    "kty": "RSA",
+                    "kid": "client1-PS256",
+                    "alg": "PS256",
+                    "n": "0J5vAPXfZS755gaBYn2PEakdHLtAmZc0cKA5wTL89V4uz9sdkiub-S91cJUTqfxqFFwFe-acTKW7-HKOusJREq3oWNyv394-2OXSDz15Lso6GEATorSRTWzfqUjogjOOBxrvxrcMyxS2RM_NjaNPw2PDWO6u0_BHPWbzyKdKbzzGsuqpd4bZ85-xzDXhXRe0n23GCnGxpPM0SvsW9CAme23-ET_F6VdfPKkX0GSU_vxdwEwGUrk5sbBmtoLcj-pfpJKaA7ZbtLsngrIVIPRNUdcP3eCPiYHrDltsi1wnWlnRj2OBcqfM6bVOQfIiVLv-UC2PgY9gmzzw-Q86GPBQOw",
+                    "e": "AQAB",
+                    "d": "rCYQ83nxHk3laSt1GREDPk-O9maOqC9d1pJhFkw88T0G4_6sKDJUQwwmnQBneZ4Q6zwESnnCAH3C3wGpRfOTcxaO5MU3XETJF7KN5IWVukamKdy2V00pmfp9lfPT6Z0hVjukIRZsOCifP6k6teZNq65nRLuxCLL-Fm0ePjXN9nty_T0XBzNeHs961zxLfc_QQFMJ46ppuLl5nBpmMErNhBwtY30y1s6cXWAhEDRvefYyhOPySCjbmUWSel7swuGxZKQIYkJS1QJ-g_e4DyVgybsY0mbaL2wNnZYW_rkVEtmII9L4tGfzcYBYd7084OXvTlh8YVuJfgxqCrIYlOQQAQ",
+                    "p": "7DcHbBqFXG6UTxX6nfI4KISyhKhAhe47H3QjBRZN03EFR0-Lpx6ncY5kiMMx_8ePPzlO_U8InG6PzhAgZFdtqJYt2lcUL50HnfPWv1KoGFe8bCNp7iYSmKT_0SjFTzBZnmoAoFcbEAzXHggWMnbMrpSLBEH64dF2GqgXXVXGEds",
+                    "q": "4hevCO5gcVC4QOZxoapdgvB0AwSiHGZEuAghrYld_6gNl42yMmOsqBhR5XgKSngUv2vrM9NkGXcURVYrcukLKT3bS5yGp5bXzMjEodDijOo33Oxz_uWtcUSH5JpB7BpUS2UuoqnJJA0YnLj_vW7jHczd33__PJ9CQSa5STA--SE",
+                    "dp": "lEuX5U5hGz5w7ZWm2TIP_6APUykuGOcPRxfqRG9UPMJfxf0yd6DPDoOOqi2hXisyy0Z3SKAtj8f5kCyfqV8aARUHhGPW0G2NMqS61TJXRbEPIfS5tEFCu4Ia-HzYIncATGvQKNmGq_TjuH7rMJNUvOWUwP-LOen-c43D3VzUFLE",
+                    "dq": "XSY21i4oC-ee0hZfcKTZPA5HLcsl4x97ZnrrLS0wThl16B_X8AzC4MqMS0dmrgHFQox67fJFBnzaHCsBYamEEKzMgd1uWPO720JISQbfoAELnPjKXZVRHR6IAnZPfK_oVNvOF_Rty22d20wZCXn7FpcGPoPkq5xN1rvWkMHQ4CE",
+                    "qi": "5d84bsBKb6u0YspU9hpc9o8F5PcJxqlwsfyOof80tUwA3NTk985cvaiXM5kQwM21q7bCyMoNfTi681MzlK1gt9GYRAHV4NJhw410mGDdnmGYFtsJwJIZbnwttYJsI0RIrk7Irom8HD2AnTvV5aI05Dxhv_-nCfn-bhy1Qqwce98"
+                }
+            ]
+        }
+    },
+    "client2": {
+        "client_id": "client2-private_key_jwt-PS256-PS256",
+        "scope": "openid email",
+        "jwks": {
+            "keys": [
+                {
+                    "use": "sig",
+                    "kty": "RSA",
+                    "kid": "client2-PS256",
+                    "alg": "PS256",
+                    "n": "6DHkboNmEegAyz9N6ux6UwEyI7a2pB3Dv-EOalRuvtqhh6jPsUd6TQZk385DzofNgYZaO1kC9wmYqD4mmQO7N6ZMvZQAbMmCat72-vHKxvZYzjcURMHTK-GDtvOUjbXzC3C0yboOS8qnO5etwho5PXETe3xdgjnERSekgAXdqzGxJEKincPWzcpoaPTpWROf4D9wNnS-rgwyd0CKp20NzoByhUtxMOKJn2t6wmBqgp7SEVOOgwRPEKMiD8u14jY-9xNfG3kOdAHMArSFb5HJN6USyFmFXROczEXOwJgvoCkY0p0hg2NCzImkPgbDmdj_otzLGjB9m3gtIoAa7THzKQ",
+                    "e": "AQAB",
+                    "d": "q9gY_q1iwkfZJpMQYJhpo7rT19im7WlV8VFn8MvSNo_qUlNeew6ydgUQbQ7j4hthvcWoTBoBdsF0aLeuqzo2ueXrD7dUZS7xxZSEZ47Bi2TQrrXW21gzqFs7txAo1oRdfw8HzfBUGkW-ZP1JzMjJqi5gw9h0ACgumRvQxCsTNlmkgKpInsBYqzASeVWFKQ5RTMHGoMoNfPJwgn1LuTi5sPKqT3n079R3M3iMKIUrzu-CWMNgtsDM9bSYAaAl6foySQS81DL_mMBuNfedOAnZcQSSjgwjI0S7GIAm4laf7692hfUk2XgqQTS5UpKRMZmsO81_1ErriSNMJI2wjKqW3Q",
+                    "p": "7P97DuHNQ9JWrtSZpIi-0fawFBVy1CpXlVeagF3Nud56VzokBTrNUNxrff04QfgMSH-cK7_DWVptBXZBeUDuxWzj82P1ms_jHNTsG87IPOOm5vWua086cvRK29INH_GHEl7reVL_VTiJlpI9NM-0sSC0DeIo5IfRuCJd9FwAXPs",
+                    "q": "-s_TXd8vASsxcf3VJButhVFo9dEVhGaKH43118DILiS1C5yfyO3z3qZ9SMtgv2L8TV3bHusVk3K35lyT93dS1505Ezh2OIX0r-_Qg23Lwyw5Dhlefty59o-o035JmgyYcHANy-WbHy3VZ3hDi3FFaqX6KvSSlG0wADhBaW687ys",
+                    "dp": "br2GI9MQ1fMP_Atta3tWJsftSMUo7ciHOko_8GFkgshZRC7vq93pGDKWq71Jr1GXc7zlHXAyeKsPLDEwsNbNe0TBUvZPSjJ_ffZkCS5bVFBPqbX89TmFJzfNTt_csCNsqQHfZ8aHdqu_ZrMYlHfFh8qvN5mI4Bgyv6aXXloq9Uc",
+                    "dq": "HsXrECR3FvSev3a-dQy0UJw5fZemxTTzk4WOeWdc6FR2pjMUY8nWVyYkTw8tEq5peHCglv2PCyVTLP-E5CMO1gejXhlaX_sHl6Kb-dQ54PuHEJTKRFR-uKLNuw1OqIkNFxaYisDkNIIiIezelLhUJQ6yUBzr8ywmbJB6bh45Ljs",
+                    "qi": "kAh6uR9qNCv9v-9vrEyqy3dnLVeW5MUtyEH1KLegrsjVlrtBTsMQGSpmXE5oMHvyiqz9e4f0FAQItQjNfIfINMNNFlukmiXFdmqUnKqVGx65cw3Yvzk-KeF8ZiEwQ_QULj7roDOZH8-XbcMjVPCOMEDM2FCMvtIxJqUr4fFJ7_E"
+                }
+            ]
+        }
+    },
+    "mtls": {
+        "cert": "-----BEGIN CERTIFICATE-----\nMIIDKDCCAs6gAwIBAgIUXl6GT8Ex1EENFSPveDA8fUoqHAwwCgYIKoZIzj0EAwIw\ndjELMAkGA1UEBhMCSlAxEzARBgNVBAgTClByaXZhdGUgQ0ExFzAVBgNVBAoTDlNl\nY3VyZSBPU1MgU2lnMRYwFAYDVQQLEw1LZXljbG9hay1mYXBpMSEwHwYDVQQDExhL\nZXljbG9hay1mYXBpIFByaXZhdGUgQ0EwHhcNMTkwNTIxMDIwNDAwWhcNMjQwNTE5\nMDIwNDAwWjBhMQswCQYDVQQGEwJKUDEPMA0GA1UECBMGQ2xpZW50MRcwFQYDVQQK\nEw5TZWN1cmUgT1NTIFNpZzEWMBQGA1UECxMNS2V5Y2xvYWstZmFwaTEQMA4GA1UE\nAxMHY2xpZW50MTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM74QUE+\nRfLtdHCKj1QXRQkj30AtveZa/7jbBpHYJCoSGA4bzuNE04HTK02hwtBO0J0bvbRy\n14BYHimwhUY6n7gtZKex3JQ39QC2UHbIOtIQXvCgbn6K4iU6WrUbCK4I8p77gIk4\nMXQmsCQokAtxsF1eq/RyLhRJXo/aTwcHDWcb5n8jFGmpOJyhmPEXwtzqMZwO9Y+a\nI3d5P/xHXnb84zrgRJH2YMzTKOfGt72I8Ag34ITTQUxox5RUMMGwqlzN6bEYIF9l\nyCcd3kCSgyp4b4wNBc5h5g3GPDBTCUx3z07oQ50LR7AAICevHvWGlUxXtX+MYc6+\nMvjb3l/e+EEldb0CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww\nCgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQURPpQRYqk1GU0v615\n9IJV4fo7s8YwHwYDVR0jBBgwFoAUJmT6o2FQqWh2KBGYB3nfWHkAtEgwCwYDVR0R\nBAQwAoIAMAoGCCqGSM49BAMCA0gAMEUCIHImOqdaMfLN1M7i4wfXKIGnJHDlEv8B\n3jASpdlMb35IAiEA5oj7fyh0KxGG9Z4kUGusBUYidOemP81CtyOPzg1A64w=\n-----END CERTIFICATE-----\n",
+        "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAzvhBQT5F8u10cIqPVBdFCSPfQC295lr/uNsGkdgkKhIYDhvO\n40TTgdMrTaHC0E7QnRu9tHLXgFgeKbCFRjqfuC1kp7HclDf1ALZQdsg60hBe8KBu\nforiJTpatRsIrgjynvuAiTgxdCawJCiQC3GwXV6r9HIuFElej9pPBwcNZxvmfyMU\naak4nKGY8RfC3OoxnA71j5ojd3k//EdedvzjOuBEkfZgzNMo58a3vYjwCDfghNNB\nTGjHlFQwwbCqXM3psRggX2XIJx3eQJKDKnhvjA0FzmHmDcY8MFMJTHfPTuhDnQtH\nsAAgJ68e9YaVTFe1f4xhzr4y+NveX974QSV1vQIDAQABAoIBAQCbyK7NXgMmi+b2\nAsVJZU54R8D1vLhQWDRdPrceNdNau03R6Mp7tEWDVaAlidlqE7jgWI4c8cgVeb4S\nYSSfrOalqb02oCDIi6nlRFUiYyorDVl4wzkIFJ+Np/O4l8WbwW5ljia8okhPBgPU\n45cwlf1K+kRx9TOL34HGw2pyfrNu5G1NWs3a30qHVc5FnKBgJq4PZgxtTC15DoQ4\nU8IF7M9XYlXOkx3zSOjk2mpQaOPDeRWBwoFsoxqOl+x3/u9rhiGW+9OXEltq+AKA\nlsZ4QVfvmjIZ65c5SJwrV+OhLIKOoA8TzheBGKZ4vkKt17GxWsm7KP1afh1fqc5C\nd1lE0e1BAoGBAPI5SKi+HKuMsWY6YLv0c6j/FHJ/ZnSLLYc6/edfXso0djuz7BOf\nmLjgnntDrWTf6jWJ14DMDZVaohFr69eham8N9H9bQl7tpdtswRL0IVfOZYbEBbQk\n57/l5yADZcxvOMne/yh8K8LARYdFe5WDHCijgLhqmENenRHhHUjAuPVxAoGBANq9\nrnqQ6j4n2GEx+YhIKOflCUWwUe9XQ8pdQwniDQkQ3imOsOLn/nMXUO1oUMbaH0cb\nQ0+e5QGW74alTaFkQxBeSTbvZplMtwgaKDl2GzlYFPUxSLkAf5crChjT0z5t74Rv\nChCvoLLxXXD+PmkC1Hpub78bfEwqit54fVGMJW8NAoGBAMzk8fZzYnMmvwU3io5T\nOOcSZqx34iXheTC0EQT/4oHvILhd+OucjCaPMuAYHnt/AXIqWJYFhdP557AO91/e\nlda9Gj4E5z6/jhXvh97Njcrlt3HpLN32fecQxZKJ7TmiN4pjzLjlWGsUE3xapTCS\nyGYD8KWO3Z/XT8xI/WmGRK6xAoGBAMBmaUr7nl4vk/7iAzehKQHYDpDSpy8bldAw\nuh++SnL3+EGbdfEP2FsJXjCEOdC+2RYlX85v18TPKz5GtgLIesix9jow1xDuTmv8\n/faU8Rs+Y6jLwcigLJodzFLMNxnJfw0A0lyc7n+XF/akWubpC1XpP7dcCLfCD8Xh\nO3F4EREdAoGAQRNaIHonLPVg+cZAVR6DAKj7l20tE1THRfHrkJDoM661hl7EnPL3\n0SoLJyKYh3uil+/XAMtdegE5nrumg25FKdDY+JvSSvqEI0dLqKZzc6PBRau3+KVU\nVAYQtvtH7E2uJ7oFzFepTp2mq1I7+BYEmTIaPDJvf/l5gz+vy+voLrs=\n-----END RSA PRIVATE KEY-----\n"
+    },
+    "mtls2": {
+        "cert": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAs6gAwIBAgIUKHCTpsodVknyAZC7gFy3hZZqTtEwCgYIKoZIzj0EAwIw\ndjELMAkGA1UEBhMCSlAxEzARBgNVBAgTClByaXZhdGUgQ0ExFzAVBgNVBAoTDlNl\nY3VyZSBPU1MgU2lnMRYwFAYDVQQLEw1LZXljbG9hay1mYXBpMSEwHwYDVQQDExhL\nZXljbG9hay1mYXBpIFByaXZhdGUgQ0EwHhcNMTkwNTIxMDIwNDAwWhcNMjQwNTE5\nMDIwNDAwWjBhMQswCQYDVQQGEwJKUDEPMA0GA1UECBMGQ2xpZW50MRcwFQYDVQQK\nEw5TZWN1cmUgT1NTIFNpZzEWMBQGA1UECxMNS2V5Y2xvYWstZmFwaTEQMA4GA1UE\nAxMHY2xpZW50MjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMlwHpEQ\nVCrBo1yRmKACefdDiGLunW+REQHmTWUTEokWdVCsMGjqns1E4h68nmXVApXtyuGL\nF3IVzJrUQ6DQXCKdPpmoFplD6aC0CdFVouY8XULyny8d1aNl+1nrFFaiamW2JxD9\nPbtUKfE/TVMM+bums+gHW63KrJo7OnfEC0wvuEwY4vVDvL5DhxoURTU8YhBUxDvA\nnfQfD4TJEVqEiIt/0vTwrdEoRlHTwaJadcyKdUKvNVG1O1RGlsPm63qS2XkG4Qvw\nasIuhoxuUZbr74S9mlDQV33k/XCWj/nOr+58xCaXNKGOI9TlFA4+YUclJxy/GeBZ\nB0OmSitP5swqpCkCAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww\nCgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUT8nMrrlLi/LQTlb3\nk6QnqLwpGT0wHwYDVR0jBBgwFoAUJmT6o2FQqWh2KBGYB3nfWHkAtEgwCwYDVR0R\nBAQwAoIAMAoGCCqGSM49BAMCA0YAMEMCID4FMD7NJZFeO4X26GifL4ODr/vK+Nje\noAcnXdYo5WX7Ah8OifloGxnCplM7doLaG+LaE8r9VEi6QyD29NAIPUPe\n-----END CERTIFICATE-----\n",
+        "key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAyXAekRBUKsGjXJGYoAJ590OIYu6db5ERAeZNZRMSiRZ1UKww\naOqezUTiHryeZdUCle3K4YsXchXMmtRDoNBcIp0+magWmUPpoLQJ0VWi5jxdQvKf\nLx3Vo2X7WesUVqJqZbYnEP09u1Qp8T9NUwz5u6az6Adbrcqsmjs6d8QLTC+4TBji\n9UO8vkOHGhRFNTxiEFTEO8Cd9B8PhMkRWoSIi3/S9PCt0ShGUdPBolp1zIp1Qq81\nUbU7VEaWw+brepLZeQbhC/Bqwi6GjG5RluvvhL2aUNBXfeT9cJaP+c6v7nzEJpc0\noY4j1OUUDj5hRyUnHL8Z4FkHQ6ZKK0/mzCqkKQIDAQABAoIBAC6BHe1rkaLVVXuX\neV7nc3TsOF5urBYHrZ98pb2B67OOZcMcHYj7MXI+Rt3FuePUi2ZFoaL0U5NZCQVt\nn7dOoxayqrMapSz5CsS5C9MyLAtvQDCmhq1/+8RfVOnrZaSilmGo7df0Pv4ybgRu\nEtHrmvQBhmM436d9tN9ecR8ZOWp66Luy1GVM6rwH6ceOc46ZHUwoumN0kQt/G72G\n0QRbt7iGle/s11TzEKh3YaR9gkS+KPm5K+iPzSP1FxDiwSrKLRQJSjANrzTKEkuQ\nyDm7MSYm23guxosA/4Oyaa+7SDEqk9509yiDp51HK9fFJWnuBoDt7iduz0VJVqHg\nq0lE9wECgYEA08hkjl9PKMTX8vN9cOX+0W4en3K10Jjonw4d2gS2dIyb8o7B4ulb\nfGpleMAmcyGuG+k8fC8nSjqYSx4YHPunbmK1O4PCGTi8r6BtD9zW8opJVi+ImMsa\nn8l8bUASOuOFrHhvnB/JZS3yoOZVE8ey6/5QtSjwbn6I7dAvXXgT5pkCgYEA837O\nFMLfbWoYvdEa9LXmXGWagQe7Ta09BGbJ1Qs1hpuZJl8qK0kVWTDURtr5yu24r7YQ\n3S3cqKcg3FB3XO+vjreYKl2Cww/v8Wy/glGgqkAhd0dP9K1Q8F8XeQPlrPkNANrG\njIlNFYmg163EDwLJ+IoRr+t43KbIoGvsb9kTdBECgYEAh1keys6mrIuA58gtdyXG\nQNp7v7Nz9yiCIoTHFzrD0KC8WbxatUYmLdFhoFZNPG9d8oCRI1yPY6UnB3roNj2u\nt6Fl6e8+8ReNn0CL8wNUbBVs4SPnzJ6hGVWPq9Ky0+fs2ljuG31FHODMm4AZB1ct\nRh12PxE296buo+3VF4tSTKECgYEA4dUW73x52rHPNqWs+Y+HkuSNMuTn3DgzYlSv\nFw+pWioQFd2nb7P9v9Yg24KWsJZgd19GLs0tXaJ8QLnEqwaGbbhrwccu0xmB8glp\naUWp3J1ULJuQVZ81dWrMi2mI6C+o1sUR5yAkxTf7XG4Ga+GrTv9HPkEHvKZXZyoR\nhP7xIvECgYB6S0i6ruOAFq2iMyGoX83RlWjo+WrGqSVWfzRZ43rFQ3MBEIlkQD3K\n6+Y+v0MMlgrN3VQTi31IW42ftgOIiy7ZndMvBaQd2Zp4POtNISsRysQJcewPwbL0\nVXsalNqW+Rl8PDzrd6s13wYogMuWrwmbPphC04LdBhZb6nX6KVkn0A==\n-----END RSA PRIVATE KEY-----\n"
+    },
+    "resource": {
+        "resourceUrl": "https://rs.keycloak-fapi.org/",
+        "institution_id": "xxx"
+    },
+    "browser": [
+        {
+            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+            "tasks": [
+                {
+                    "task": "Initial Login",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "optional": true,
+                    "commands": [
+                        [
+                            "text",
+                            "name",
+                            "username",
+                            "john"
+                        ],
+                        [
+                            "text",
+                            "name",
+                            "password",
+                            "john"
+                        ],
+                        [
+                            "click",
+                            "name",
+                            "login"
+                        ]
+                    ]
+                },
+                {
+                    "task": "Verify Complete",
+                    "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                    "commands": [
+                        [
+                            "wait",
+                            "id",
+                            "submission_complete",
+                            10
+                        ]
+                    ]
+                }
+            ]
+        }
+    ],
+    "override": {
+        "fapi-rw-id2": {
+            "browser": [
+                {
+                    "comment": "Must grant consent to user attributes being shared in first browser login for user john",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "optional": true,
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "john"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "john"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Grant Consent",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "optional": true,
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "accept"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-user-rejects-authentication": {
+            "browser": [
+                {
+                    "comment": "Expect user to deny consent after initial login",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-response-mode-query": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-registered-redirect-uri": {
+            "browser": [
+                {
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "xpath",
+                                    "//p[text()='Invalid parameter: redirect_uri']",
+                                    10,
+                                    ".*Invalid parameter: redirect_uri.*",
+                                    "update-image-placeholder"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-request-object-without-exp-fails": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-request-object-without-scope-fails": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-state-only-outside-request-object-not-used": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-request-object-without-nonce-fails": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-request-object-without-redirect-uri-fails": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-expired-request-object-fails": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-different-nonce-inside-and-outside-request-object": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+         "fapi-rw-id2-ensure-response-type-code-fails": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-request-object-with-bad-aud-fails": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "mike"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "mike"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Authorize Client",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/login-actions/required-action*",
+                            "commands": [
+                                [
+                                    "click",
+                                    "name",
+                                    "cancel"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-matching-key-in-authorization-request": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "expect an immediate redirect back to the conformance suite with an error",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "xpath",
+                                    "//*",
+                                    10,
+                                    ".*",
+                                    "update-image-placeholder"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-authorization-request-without-request-object-fails": {
+            "browser": [
+                {
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "xpath",
+                                    "//p[text()='Invalid Request']",
+                                    10,
+                                    ".*Invalid Request.*",
+                                    "update-image-placeholder"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-redirect-uri-in-authorization-request": {
+            "browser": [
+                {
+                    "comment": "expect an immediate error page",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Expect redirect uri mismatch error page",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "xpath",
+                                    "//*",
+                                    10,
+                                    ".*Invalid parameter: redirect_uri.*",
+                                    "update-image-placeholder"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-client-id-in-token-endpoint": {
+            "browser": [
+                {
+                    "comment": "expect an immediate redirect back to the conformance suite with an error",
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Initial login",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "text",
+                                    "id",
+                                    "username",
+                                    "john"
+                                ],
+                                [
+                                    "text",
+                                    "id",
+                                    "password",
+                                    "john"
+                                ],
+                                [
+                                    "click",
+                                    "name",
+                                    "login"
+                                ]
+                            ]
+                        },
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://conformance-suite.keycloak-fapi.org/test/a/keycloak/callback*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "id",
+                                    "submission_complete",
+                                    10
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-signed-request-object-with-RS256-fails": {
+            "browser": [
+                {
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "xpath",
+                                    "//p[text()='Invalid Request']",
+                                    10,
+                                    ".*Invalid Request.*",
+                                    "update-image-placeholder"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-request-object-with-invalid-signature-fails": {
+            "browser": [
+                {
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "xpath",
+                                    "//p[text()='Invalid Request']",
+                                    10,
+                                    ".*Invalid Request.*",
+                                    "update-image-placeholder"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "fapi-rw-id2-ensure-request-object-signature-algorithm-is-not-none": {
+            "browser": [
+                {
+                    "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                    "tasks": [
+                        {
+                            "task": "Verify Complete",
+                            "match": "https://as.keycloak-fapi.org/auth/realms/test/protocol/openid-connect/auth*",
+                            "commands": [
+                                [
+                                    "wait",
+                                    "xpath",
+                                    "//p[text()='Invalid Request']",
+                                    10,
+                                    ".*Invalid Request.*",
+                                    "update-image-placeholder"
+                                ]
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-PS256-PS256.json
+++ b/fapi-conformance-suite-configs/fapi-rw-id2-with-private-key-PS256-PS256.json
@@ -8,45 +8,45 @@
         "client_id": "client1-private_key_jwt-PS256-PS256",
         "scope": "openid email",
         "jwks": {
-    "keys": [
-        {
-            "use": "sig",
-            "kty": "RSA",
-            "kid": "client1-PS256",
-            "alg": "PS256",
-            "n": "0J5vAPXfZS755gaBYn2PEakdHLtAmZc0cKA5wTL89V4uz9sdkiub-S91cJUTqfxqFFwFe-acTKW7-HKOusJREq3oWNyv394-2OXSDz15Lso6GEATorSRTWzfqUjogjOOBxrvxrcMyxS2RM_NjaNPw2PDWO6u0_BHPWbzyKdKbzzGsuqpd4bZ85-xzDXhXRe0n23GCnGxpPM0SvsW9CAme23-ET_F6VdfPKkX0GSU_vxdwEwGUrk5sbBmtoLcj-pfpJKaA7ZbtLsngrIVIPRNUdcP3eCPiYHrDltsi1wnWlnRj2OBcqfM6bVOQfIiVLv-UC2PgY9gmzzw-Q86GPBQOw",
-            "e": "AQAB",
-            "d": "rCYQ83nxHk3laSt1GREDPk-O9maOqC9d1pJhFkw88T0G4_6sKDJUQwwmnQBneZ4Q6zwESnnCAH3C3wGpRfOTcxaO5MU3XETJF7KN5IWVukamKdy2V00pmfp9lfPT6Z0hVjukIRZsOCifP6k6teZNq65nRLuxCLL-Fm0ePjXN9nty_T0XBzNeHs961zxLfc_QQFMJ46ppuLl5nBpmMErNhBwtY30y1s6cXWAhEDRvefYyhOPySCjbmUWSel7swuGxZKQIYkJS1QJ-g_e4DyVgybsY0mbaL2wNnZYW_rkVEtmII9L4tGfzcYBYd7084OXvTlh8YVuJfgxqCrIYlOQQAQ",
-            "p": "7DcHbBqFXG6UTxX6nfI4KISyhKhAhe47H3QjBRZN03EFR0-Lpx6ncY5kiMMx_8ePPzlO_U8InG6PzhAgZFdtqJYt2lcUL50HnfPWv1KoGFe8bCNp7iYSmKT_0SjFTzBZnmoAoFcbEAzXHggWMnbMrpSLBEH64dF2GqgXXVXGEds",
-            "q": "4hevCO5gcVC4QOZxoapdgvB0AwSiHGZEuAghrYld_6gNl42yMmOsqBhR5XgKSngUv2vrM9NkGXcURVYrcukLKT3bS5yGp5bXzMjEodDijOo33Oxz_uWtcUSH5JpB7BpUS2UuoqnJJA0YnLj_vW7jHczd33__PJ9CQSa5STA--SE",
-            "dp": "lEuX5U5hGz5w7ZWm2TIP_6APUykuGOcPRxfqRG9UPMJfxf0yd6DPDoOOqi2hXisyy0Z3SKAtj8f5kCyfqV8aARUHhGPW0G2NMqS61TJXRbEPIfS5tEFCu4Ia-HzYIncATGvQKNmGq_TjuH7rMJNUvOWUwP-LOen-c43D3VzUFLE",
-            "dq": "XSY21i4oC-ee0hZfcKTZPA5HLcsl4x97ZnrrLS0wThl16B_X8AzC4MqMS0dmrgHFQox67fJFBnzaHCsBYamEEKzMgd1uWPO720JISQbfoAELnPjKXZVRHR6IAnZPfK_oVNvOF_Rty22d20wZCXn7FpcGPoPkq5xN1rvWkMHQ4CE",
-            "qi": "5d84bsBKb6u0YspU9hpc9o8F5PcJxqlwsfyOof80tUwA3NTk985cvaiXM5kQwM21q7bCyMoNfTi681MzlK1gt9GYRAHV4NJhw410mGDdnmGYFtsJwJIZbnwttYJsI0RIrk7Irom8HD2AnTvV5aI05Dxhv_-nCfn-bhy1Qqwce98"
+            "keys": [
+                {
+                    "use": "sig",
+                    "kty": "RSA",
+                    "kid": "client1-PS256",
+                    "alg": "PS256",
+                    "n": "0J5vAPXfZS755gaBYn2PEakdHLtAmZc0cKA5wTL89V4uz9sdkiub-S91cJUTqfxqFFwFe-acTKW7-HKOusJREq3oWNyv394-2OXSDz15Lso6GEATorSRTWzfqUjogjOOBxrvxrcMyxS2RM_NjaNPw2PDWO6u0_BHPWbzyKdKbzzGsuqpd4bZ85-xzDXhXRe0n23GCnGxpPM0SvsW9CAme23-ET_F6VdfPKkX0GSU_vxdwEwGUrk5sbBmtoLcj-pfpJKaA7ZbtLsngrIVIPRNUdcP3eCPiYHrDltsi1wnWlnRj2OBcqfM6bVOQfIiVLv-UC2PgY9gmzzw-Q86GPBQOw",
+                    "e": "AQAB",
+                    "d": "rCYQ83nxHk3laSt1GREDPk-O9maOqC9d1pJhFkw88T0G4_6sKDJUQwwmnQBneZ4Q6zwESnnCAH3C3wGpRfOTcxaO5MU3XETJF7KN5IWVukamKdy2V00pmfp9lfPT6Z0hVjukIRZsOCifP6k6teZNq65nRLuxCLL-Fm0ePjXN9nty_T0XBzNeHs961zxLfc_QQFMJ46ppuLl5nBpmMErNhBwtY30y1s6cXWAhEDRvefYyhOPySCjbmUWSel7swuGxZKQIYkJS1QJ-g_e4DyVgybsY0mbaL2wNnZYW_rkVEtmII9L4tGfzcYBYd7084OXvTlh8YVuJfgxqCrIYlOQQAQ",
+                    "p": "7DcHbBqFXG6UTxX6nfI4KISyhKhAhe47H3QjBRZN03EFR0-Lpx6ncY5kiMMx_8ePPzlO_U8InG6PzhAgZFdtqJYt2lcUL50HnfPWv1KoGFe8bCNp7iYSmKT_0SjFTzBZnmoAoFcbEAzXHggWMnbMrpSLBEH64dF2GqgXXVXGEds",
+                    "q": "4hevCO5gcVC4QOZxoapdgvB0AwSiHGZEuAghrYld_6gNl42yMmOsqBhR5XgKSngUv2vrM9NkGXcURVYrcukLKT3bS5yGp5bXzMjEodDijOo33Oxz_uWtcUSH5JpB7BpUS2UuoqnJJA0YnLj_vW7jHczd33__PJ9CQSa5STA--SE",
+                    "dp": "lEuX5U5hGz5w7ZWm2TIP_6APUykuGOcPRxfqRG9UPMJfxf0yd6DPDoOOqi2hXisyy0Z3SKAtj8f5kCyfqV8aARUHhGPW0G2NMqS61TJXRbEPIfS5tEFCu4Ia-HzYIncATGvQKNmGq_TjuH7rMJNUvOWUwP-LOen-c43D3VzUFLE",
+                    "dq": "XSY21i4oC-ee0hZfcKTZPA5HLcsl4x97ZnrrLS0wThl16B_X8AzC4MqMS0dmrgHFQox67fJFBnzaHCsBYamEEKzMgd1uWPO720JISQbfoAELnPjKXZVRHR6IAnZPfK_oVNvOF_Rty22d20wZCXn7FpcGPoPkq5xN1rvWkMHQ4CE",
+                    "qi": "5d84bsBKb6u0YspU9hpc9o8F5PcJxqlwsfyOof80tUwA3NTk985cvaiXM5kQwM21q7bCyMoNfTi681MzlK1gt9GYRAHV4NJhw410mGDdnmGYFtsJwJIZbnwttYJsI0RIrk7Irom8HD2AnTvV5aI05Dxhv_-nCfn-bhy1Qqwce98"
+                }
+            ]
         }
-    ]
-} 
     },
     "client2": {
         "client_id": "client2-private_key_jwt-PS256-PS256",
         "scope": "openid email",
         "jwks": {
-    "keys": [
-        {
-            "use": "sig",
-            "kty": "RSA",
-            "kid": "client2-PS256",
-            "alg": "PS256",
-            "n": "6DHkboNmEegAyz9N6ux6UwEyI7a2pB3Dv-EOalRuvtqhh6jPsUd6TQZk385DzofNgYZaO1kC9wmYqD4mmQO7N6ZMvZQAbMmCat72-vHKxvZYzjcURMHTK-GDtvOUjbXzC3C0yboOS8qnO5etwho5PXETe3xdgjnERSekgAXdqzGxJEKincPWzcpoaPTpWROf4D9wNnS-rgwyd0CKp20NzoByhUtxMOKJn2t6wmBqgp7SEVOOgwRPEKMiD8u14jY-9xNfG3kOdAHMArSFb5HJN6USyFmFXROczEXOwJgvoCkY0p0hg2NCzImkPgbDmdj_otzLGjB9m3gtIoAa7THzKQ",
-            "e": "AQAB",
-            "d": "q9gY_q1iwkfZJpMQYJhpo7rT19im7WlV8VFn8MvSNo_qUlNeew6ydgUQbQ7j4hthvcWoTBoBdsF0aLeuqzo2ueXrD7dUZS7xxZSEZ47Bi2TQrrXW21gzqFs7txAo1oRdfw8HzfBUGkW-ZP1JzMjJqi5gw9h0ACgumRvQxCsTNlmkgKpInsBYqzASeVWFKQ5RTMHGoMoNfPJwgn1LuTi5sPKqT3n079R3M3iMKIUrzu-CWMNgtsDM9bSYAaAl6foySQS81DL_mMBuNfedOAnZcQSSjgwjI0S7GIAm4laf7692hfUk2XgqQTS5UpKRMZmsO81_1ErriSNMJI2wjKqW3Q",
-            "p": "7P97DuHNQ9JWrtSZpIi-0fawFBVy1CpXlVeagF3Nud56VzokBTrNUNxrff04QfgMSH-cK7_DWVptBXZBeUDuxWzj82P1ms_jHNTsG87IPOOm5vWua086cvRK29INH_GHEl7reVL_VTiJlpI9NM-0sSC0DeIo5IfRuCJd9FwAXPs",
-            "q": "-s_TXd8vASsxcf3VJButhVFo9dEVhGaKH43118DILiS1C5yfyO3z3qZ9SMtgv2L8TV3bHusVk3K35lyT93dS1505Ezh2OIX0r-_Qg23Lwyw5Dhlefty59o-o035JmgyYcHANy-WbHy3VZ3hDi3FFaqX6KvSSlG0wADhBaW687ys",
-            "dp": "br2GI9MQ1fMP_Atta3tWJsftSMUo7ciHOko_8GFkgshZRC7vq93pGDKWq71Jr1GXc7zlHXAyeKsPLDEwsNbNe0TBUvZPSjJ_ffZkCS5bVFBPqbX89TmFJzfNTt_csCNsqQHfZ8aHdqu_ZrMYlHfFh8qvN5mI4Bgyv6aXXloq9Uc",
-            "dq": "HsXrECR3FvSev3a-dQy0UJw5fZemxTTzk4WOeWdc6FR2pjMUY8nWVyYkTw8tEq5peHCglv2PCyVTLP-E5CMO1gejXhlaX_sHl6Kb-dQ54PuHEJTKRFR-uKLNuw1OqIkNFxaYisDkNIIiIezelLhUJQ6yUBzr8ywmbJB6bh45Ljs",
-            "qi": "kAh6uR9qNCv9v-9vrEyqy3dnLVeW5MUtyEH1KLegrsjVlrtBTsMQGSpmXE5oMHvyiqz9e4f0FAQItQjNfIfINMNNFlukmiXFdmqUnKqVGx65cw3Yvzk-KeF8ZiEwQ_QULj7roDOZH8-XbcMjVPCOMEDM2FCMvtIxJqUr4fFJ7_E"
+            "keys": [
+                {
+                    "use": "sig",
+                    "kty": "RSA",
+                    "kid": "client2-PS256",
+                    "alg": "PS256",
+                    "n": "6DHkboNmEegAyz9N6ux6UwEyI7a2pB3Dv-EOalRuvtqhh6jPsUd6TQZk385DzofNgYZaO1kC9wmYqD4mmQO7N6ZMvZQAbMmCat72-vHKxvZYzjcURMHTK-GDtvOUjbXzC3C0yboOS8qnO5etwho5PXETe3xdgjnERSekgAXdqzGxJEKincPWzcpoaPTpWROf4D9wNnS-rgwyd0CKp20NzoByhUtxMOKJn2t6wmBqgp7SEVOOgwRPEKMiD8u14jY-9xNfG3kOdAHMArSFb5HJN6USyFmFXROczEXOwJgvoCkY0p0hg2NCzImkPgbDmdj_otzLGjB9m3gtIoAa7THzKQ",
+                    "e": "AQAB",
+                    "d": "q9gY_q1iwkfZJpMQYJhpo7rT19im7WlV8VFn8MvSNo_qUlNeew6ydgUQbQ7j4hthvcWoTBoBdsF0aLeuqzo2ueXrD7dUZS7xxZSEZ47Bi2TQrrXW21gzqFs7txAo1oRdfw8HzfBUGkW-ZP1JzMjJqi5gw9h0ACgumRvQxCsTNlmkgKpInsBYqzASeVWFKQ5RTMHGoMoNfPJwgn1LuTi5sPKqT3n079R3M3iMKIUrzu-CWMNgtsDM9bSYAaAl6foySQS81DL_mMBuNfedOAnZcQSSjgwjI0S7GIAm4laf7692hfUk2XgqQTS5UpKRMZmsO81_1ErriSNMJI2wjKqW3Q",
+                    "p": "7P97DuHNQ9JWrtSZpIi-0fawFBVy1CpXlVeagF3Nud56VzokBTrNUNxrff04QfgMSH-cK7_DWVptBXZBeUDuxWzj82P1ms_jHNTsG87IPOOm5vWua086cvRK29INH_GHEl7reVL_VTiJlpI9NM-0sSC0DeIo5IfRuCJd9FwAXPs",
+                    "q": "-s_TXd8vASsxcf3VJButhVFo9dEVhGaKH43118DILiS1C5yfyO3z3qZ9SMtgv2L8TV3bHusVk3K35lyT93dS1505Ezh2OIX0r-_Qg23Lwyw5Dhlefty59o-o035JmgyYcHANy-WbHy3VZ3hDi3FFaqX6KvSSlG0wADhBaW687ys",
+                    "dp": "br2GI9MQ1fMP_Atta3tWJsftSMUo7ciHOko_8GFkgshZRC7vq93pGDKWq71Jr1GXc7zlHXAyeKsPLDEwsNbNe0TBUvZPSjJ_ffZkCS5bVFBPqbX89TmFJzfNTt_csCNsqQHfZ8aHdqu_ZrMYlHfFh8qvN5mI4Bgyv6aXXloq9Uc",
+                    "dq": "HsXrECR3FvSev3a-dQy0UJw5fZemxTTzk4WOeWdc6FR2pjMUY8nWVyYkTw8tEq5peHCglv2PCyVTLP-E5CMO1gejXhlaX_sHl6Kb-dQ54PuHEJTKRFR-uKLNuw1OqIkNFxaYisDkNIIiIezelLhUJQ6yUBzr8ywmbJB6bh45Ljs",
+                    "qi": "kAh6uR9qNCv9v-9vrEyqy3dnLVeW5MUtyEH1KLegrsjVlrtBTsMQGSpmXE5oMHvyiqz9e4f0FAQItQjNfIfINMNNFlukmiXFdmqUnKqVGx65cw3Yvzk-KeF8ZiEwQ_QULj7roDOZH8-XbcMjVPCOMEDM2FCMvtIxJqUr4fFJ7_E"
+                }
+            ]
         }
-    ]
-} 
     },
     "mtls": {
         "cert": "-----BEGIN CERTIFICATE-----\nMIIDKDCCAs6gAwIBAgIUXl6GT8Ex1EENFSPveDA8fUoqHAwwCgYIKoZIzj0EAwIw\ndjELMAkGA1UEBhMCSlAxEzARBgNVBAgTClByaXZhdGUgQ0ExFzAVBgNVBAoTDlNl\nY3VyZSBPU1MgU2lnMRYwFAYDVQQLEw1LZXljbG9hay1mYXBpMSEwHwYDVQQDExhL\nZXljbG9hay1mYXBpIFByaXZhdGUgQ0EwHhcNMTkwNTIxMDIwNDAwWhcNMjQwNTE5\nMDIwNDAwWjBhMQswCQYDVQQGEwJKUDEPMA0GA1UECBMGQ2xpZW50MRcwFQYDVQQK\nEw5TZWN1cmUgT1NTIFNpZzEWMBQGA1UECxMNS2V5Y2xvYWstZmFwaTEQMA4GA1UE\nAxMHY2xpZW50MTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM74QUE+\nRfLtdHCKj1QXRQkj30AtveZa/7jbBpHYJCoSGA4bzuNE04HTK02hwtBO0J0bvbRy\n14BYHimwhUY6n7gtZKex3JQ39QC2UHbIOtIQXvCgbn6K4iU6WrUbCK4I8p77gIk4\nMXQmsCQokAtxsF1eq/RyLhRJXo/aTwcHDWcb5n8jFGmpOJyhmPEXwtzqMZwO9Y+a\nI3d5P/xHXnb84zrgRJH2YMzTKOfGt72I8Ag34ITTQUxox5RUMMGwqlzN6bEYIF9l\nyCcd3kCSgyp4b4wNBc5h5g3GPDBTCUx3z07oQ50LR7AAICevHvWGlUxXtX+MYc6+\nMvjb3l/e+EEldb0CAwEAAaOBgzCBgDAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAww\nCgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQURPpQRYqk1GU0v615\n9IJV4fo7s8YwHwYDVR0jBBgwFoAUJmT6o2FQqWh2KBGYB3nfWHkAtEgwCwYDVR0R\nBAQwAoIAMAoGCCqGSM49BAMCA0gAMEUCIHImOqdaMfLN1M7i4wfXKIGnJHDlEv8B\n3jASpdlMb35IAiEA5oj7fyh0KxGG9Z4kUGusBUYidOemP81CtyOPzg1A64w=\n-----END CERTIFICATE-----\n",
@@ -59,47 +59,5 @@
     "resource": {
         "resourceUrl": "https://rs.keycloak-fapi.org/",
         "institution_id": "xxx"
-    },
-    "browser": [
-        {
-            "match": "https://as.keycloak-fapi.org/auth/realms/test/openid-connect/auth*",
-            "tasks": [
-                {
-                    "task": "Initial Login",
-                    "match": "https://as.keycloak-fapi.org/auth/realms/test/openid-connect/auth*",
-                    "commands": [
-                        [
-                            "text",
-                            "name",
-                            "username",
-                            "john"
-                        ],
-                        [
-                            "text",
-                            "name",
-                            "password",
-                            "john"
-                        ],
-                        [
-                            "click",
-                            "name",
-                            "login"
-                        ]
-                    ]
-                },
-                {
-                    "task": "Verify Complete",
-                    "match": "https://*/test/a/keycloak/callback*",
-                    "commands": [
-                        [
-                            "wait",
-                            "id",
-                            "submission_complete",
-                            10
-                        ]
-                    ]
-                }
-            ]
-        }
-    ]
+    }
 }

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,12 +1,13 @@
-FROM quay.io/keycloak/keycloak:11.0.1
-
+ARG KEYCLOAK_BASE_IMAGE
+FROM ${KEYCLOAK_BASE_IMAGE}
+ARG KEYCLOAK_REALM_IMPORT_FILENAME
 # For FAPI-RW-8.5-2
 RUN sed -i -e "s/(key-manager=kcKeyManager)/(key-manager=kcKeyManager,protocols=[\"TLSv1.2\"],cipher-suite-filter=\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\")/" /opt/jboss/tools/cli/x509-keystore.cli
 
 USER root
 
 # Realm config
-ADD --chown=jboss:jboss realm.json /opt/jboss/
+ADD --chown=jboss:jboss ${KEYCLOAK_REALM_IMPORT_FILENAME} /opt/jboss/
 
-ENV KEYCLOAK_IMPORT=/opt/jboss/realm.json
+ENV KEYCLOAK_IMPORT=/opt/jboss/${KEYCLOAK_REALM_IMPORT_FILENAME}
 ENV X509_CA_BUNDLE=/etc/x509/https/client-ca.crt

--- a/keycloak/realm-local.json
+++ b/keycloak/realm-local.json
@@ -1174,6 +1174,149 @@
                     ]
                 }
             }
-        ]
+        ],
+        "org.keycloak.services.clientpolicy.ClientPolicyProvider" : [ {
+            "name" : "MyPolicy",
+            "providerId" : "client-policy-provider",
+            "subComponents" : { },
+            "config" : {
+                "client-policy-executor-ids" : [ "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf", "47e818e3-f0d8-4a90-ace7-1a8b2362cec7" ],
+                "client-policy-condition-ids" : [ "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146" ]
+            }
+        } ],
+        "org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider" : [ {
+            "id" : "47e818e3-f0d8-4a90-ace7-1a8b2362cec7",
+            "name" : "SecureRequestObjectExecutor",
+            "providerId" : "secure-reqobj-executor",
+            "subComponents" : { },
+            "config" : { }
+        }, {
+            "id" : "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf",
+            "name" : "SecureResponseTypeExecutor",
+            "providerId" : "secure-responsetype-executor",
+            "subComponents" : { },
+            "config" : { }
+        } ],
+        "org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider" : [ {
+            "id" : "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146",
+            "name" : "ClientRolesCondition",
+            "providerId" : "clientroles-condition",
+            "subComponents" : { },
+            "config" : {
+                "roles" : [ "sample-client-role" ]
+            }
+        } ]
+    },
+    "roles" : {
+        "realm" : [ {
+            "name" : "sample-realm-role",
+            "description" : "Sample realm role",
+            "composite" : false,
+            "clientRole" : false,
+            "containerId" : "test",
+            "attributes" : { }
+        }, {
+            "name" : "realm-composite-role",
+            "description" : "Realm composite role containing client role",
+            "composite" : true,
+            "composites" : {
+                "realm" : [ "sample-realm-role" ],
+                "client" : {
+                    "client1-mtls-PS256-PS256" : [ "sample-client-role" ],
+                    "client2-mtls-PS256-PS256" : [ "sample-client-role" ],
+                    "client1-mtls-ES256-ES256" : [ "sample-client-role" ],
+                    "client2-mtls-ES256-ES256" : [ "sample-client-role" ],
+                    "client1-private_key_jwt-PS256-PS256" : [ "sample-client-role" ],
+                    "client2-private_key_jwt-PS256-PS256" : [ "sample-client-role" ],
+                    "client1-private_key_jwt-ES256-ES256" : [ "sample-client-role" ],
+                    "client2-private_key_jwt-ES256-ES256" : [ "sample-client-role" ]
+                }
+            },
+            "clientRole" : false,
+            "containerId" : "test",
+            "attributes" : { }
+        } ],
+        "client" : {
+            "client1-mtls-PS256-PS256" : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "c61d93dc-467d-4fa9-9b58-6d21e2276eac",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ],
+            "client2-mtls-PS256-PS256" : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "fe548191-270e-4749-bcae-930a9abbc66e",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ],
+            "client1-mtls-ES256-ES256" : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "5826281c-f5c0-4d06-a49f-0b877b49dd8e",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ],
+            "client2-mtls-ES256-ES256" : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "7e359b9f-a9ed-41d3-8bef-5323191ad7a1",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ],
+            "client1-private_key_jwt-PS256-PS256"  : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "0380f98c-7567-40e7-9e4a-82f0249dc4e7",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ],
+            "client2-private_key_jwt-PS256-PS256"  : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "2c93ead7-256f-4260-848a-207b4ffe740b",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ],
+            "client1-private_key_jwt-ES256-ES256"  : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "a40263fd-7e4a-4c63-9544-763dd178fffb",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ],
+            "client2-private_key_jwt-ES256-ES256"  : [ {
+                "name" : "sample-client-role",
+                "description" : "Sample client role",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "227af5b9-0899-4949-8c0f-85bad117a14c",
+                "attributes" : {
+                    "sample-client-role-attribute" : [ "sample-client-role-attribute-value" ]
+                }
+            } ]
+        }
     }
 }

--- a/test-runner/Dockerfile
+++ b/test-runner/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker/compose:latest
+ADD test-runner-entrypoint.sh .
+RUN apk add --update --upgrade --no-cache  curl
+CMD [ "sh", "./test-runner-entrypoint.sh" ]

--- a/test-runner/test-runner-entrypoint.sh
+++ b/test-runner/test-runner-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Wait for server to start before running tests - check every 30s
+until $(curl -k --output /dev/null --silent --head --fail https://host.docker.internal:8443)
+do
+    sleep 30
+done
+
+# Sometimes keycloak is still starting up at this point if no maven dependencies need downloading in server service (sleep 20)
+sleep 20
+ 
+[ $AUTOMATE_TESTS == true ] &&
+docker exec keycloak-fapi_server_1 bash -c "/conformance-suite/.gitlab-ci/run-tests.sh --server-tests-only"


### PR DESCRIPTION
Key functions:

- Can be run with a single command
- Test reports (provided by OpenID Conformance Suite API, in plain text) exported to source directory using docker volume
- Parameterised with env vars for various custom behaviour
- All browser interactions automated
- Can be extended to include other test plans, such as FAPI-CIBA
- Contains static copy of OpenID Conformance Suite rather than using docker to clone project - UPDATE: Now cloning tagged versions of OpenID Conformance Suite. Tag can be specified with environment variable in command line.
- Currently, this is only automating the fapi-rw-id2-test-plan using fapi-rw-id2-with-private-key-PS256-PS256.json config
 (with variant [client_auth_type=private_key_jwt][fapi_profile=plain_fapi][fapi_response_mode=plain_response][fapi_auth_request_method=by_value])