### PR TITLE
upgrade default conformance test version from 4.1.4 to 4.1.6 and confirm that all FAPI-RW conformance tests are passed against 12.0.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 OPENID_GIT_URL=https://gitlab.com/openid/conformance-suite.git
-OPENID_GIT_TAG=${OPENID_GIT_TAG:-release-v4.1.4}
+OPENID_GIT_TAG=${OPENID_GIT_TAG:-release-v4.1.6}
 
 KEYCLOAK_REALM=test
 KEYCLOAK_USER=admin
@@ -10,6 +10,6 @@ RESOURCE_FQDN=rs.keycloak-fapi.org
 CONFORMANCE_SUITE_FQDN=conformance-suite.keycloak-fapi.org
 
 AUTOMATE_TESTS=${AUTOMATE_TESTS:-true}
-KEYCLOAK_BASE_IMAGE=${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:12.0.1}
+KEYCLOAK_BASE_IMAGE=${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:12.0.4}
 KEYCLOAK_REALM_IMPORT_FILENAME=${KEYCLOAK_REALM_IMPORT_FILENAME:-realm.json}
 MVN_HOME=${MVN_HOME:-~/.m2}


### PR DESCRIPTION
On 12 Mar 2021, the final version of FAPI 1.0 is published by [OID-F](https://openid.net/2021/03/12/fapi-1-0-part-1-and-part-2-are-now-final-specifications/).

To check whether the current keycloak can pass the conformance tests incorporating this final version, I would like to update the latest version of the conformance test (release-v4.1.6) But, I'm not sure whether this version incorporates the difference between ID2 and Final version of FAPI 1.0.

As the result, I've confirmed that the latest keycloak (12.0.4) could pass all conformance tests of both FAPI-RW OP w/Private Key and FAPI-RW OP w/MTLS on each PS256 and ES256 of the client's signature algorithm. ES256's case have some skipped test but I think those are not so serious issues.