### PR TITLE
Fix the automated run of OIDC conformance testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you would like to use the configurations as it is, you only need to build and
 Run the following command from the project basedir to start the test suite
 
 ```
-docker-compose up --build
+docker-compose -p keycloak-fapi up --build
 ```
 The OpenID FAPI Conformance test interface will then be reachable at [https://localhost:8443](https://localhost:8443).
 See instructions in [Run FAPI Conformance test plan](#Run-FAPI-Conformance-test-plan) 
@@ -77,7 +77,7 @@ section for running the tests manually in your browser.
 To stop all containers after the automated tests have run:
 
 ```
-docker-compose up --build --exit-code-from test_runner
+docker-compose -p keycloak-fapi up --build --exit-code-from test_runner
 ```
 
 The following options can be set as environment variables before the above command:
@@ -97,7 +97,7 @@ The following options can be set as environment variables before the above comma
 
 **Example:**
 ```
-KEYCLOAK_BASE_IMAGE=jboss/keycloak:6.0.1 docker-compose up --build
+KEYCLOAK_BASE_IMAGE=jboss/keycloak:6.0.1 docker-compose -p keycloak-fapi up --build
 ```
 
 To stop and remove all containers, run the following:
@@ -148,7 +148,7 @@ Run `generate-all.sh` script simply to generate self-signed certificates for HTT
 Now, you can boot a Keycloak server with new configurations.
 
 ```
-docker-compose up --force-recreate
+docker-compose -p keycloak-fapi up --force-recreate
 ```
 
 ## Run FAPI Conformance test against local built keycloak
@@ -171,7 +171,7 @@ It overrides the keycloak of the base image with the one built on the local mach
 Then run the FAPI Conformance Suite with KEYCLOAK_REALM_IMPORT_FILENAME env var:
 
 ```
-KEYCLOAK_REALM_IMPORT_FILENAME=realm-local.json docker-compose up --build
+KEYCLOAK_REALM_IMPORT_FILENAME=realm-local.json docker-compose -p keycloak-fapi up --build
 ```
 
 ## Run FAPI Conformance test with persistent OpenID Server DB volume

--- a/test-runner/test-runner-entrypoint.sh
+++ b/test-runner/test-runner-entrypoint.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 
 # Wait for server to start before running tests - check every 30s
-until $(curl -k --output /dev/null --silent --head --fail https://host.docker.internal:8443)
+# On some platforms (For example Ubuntu 18.0.4), the docker host available on 172.17.0.1
+until $(curl -k --output /dev/null --silent --head --fail https://host.docker.internal:8443) ||  $(curl -k --output /dev/null --silent --head --fail https://172.17.0.1:8443)
 do
+    echo "Still waiting for 'docker internal host' to be available";
     sleep 30
 done
 
+echo "The 'docker internal host' available. Waiting 20 seconds before starting tests"
+
 # Sometimes keycloak is still starting up at this point if no maven dependencies need downloading in server service (sleep 20)
 sleep 20
+
+docker exec keycloak-fapi_server_1 bash -c "chmod a+x /conformance-suite/.gitlab-ci/run-tests.sh"
+docker exec keycloak-fapi_server_1 bash -c "chmod a+x /conformance-suite/scripts/*"
  
 [ $AUTOMATE_TESTS == true ] &&
 docker exec keycloak-fapi_server_1 bash -c "/conformance-suite/.gitlab-ci/run-tests.sh --server-tests-only"


### PR DESCRIPTION
@tnorimat @VinodAnandan Do you please have a chance to review this PR? I've tried to run FAPI conformance testsuite locally on my laptop based on the instructions from README. These are changes needed in order to successfully run the testsuite on my laptop:
- Changed the `docker-compose` commands in the README and added explicitly option "-p" with the project name when running docker-compose . Without this change, docker-compose is using the directory name as the default project name. And the directory name is in my case "kc-sig-fapi" after checkout this project from github (as the name of the repository is also "kc-sig-fapi" . In my case, there were some failures due to this. So this change adds some resiliency to not be dependent on the directory name.
- The test failed to execute as `host.docker.internal` is not available on my platform (Ubuntu 18.0.4). I checked that in my case it is IP address 172.17.0.1 . So added this as another option for checking.
- Needed to add `chmod` as some scripts were not runnable by default