### PR TITLE
Update conformance testsuite to use the default FAPI 1 global advanced profile - slightly modified for ID2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
      - ./https/server.pem:/etc/x509/https/tls.crt
      - ./https/server-key.pem:/etc/x509/https/tls.key
      - ./https/client-ca.pem:/etc/x509/https/client-ca.crt
-#     - ../bin/keycloak-conformance-test:/opt/jboss/keycloak
+     - /tmp/keycloak-14.0.0-SNAPSHOT:/opt/jboss/keycloak
     command: "-b 0.0.0.0 -Djboss.socket.binding.port-offset=1000 --debug -Dkeycloak.profile=preview"
   api_gateway_nginx:
     build:

--- a/keycloak/realm-local.json
+++ b/keycloak/realm-local.json
@@ -1174,37 +1174,72 @@
                     ]
                 }
             }
-        ],
-        "org.keycloak.services.clientpolicy.ClientPolicyProvider" : [ {
-            "name" : "MyPolicy",
-            "providerId" : "client-policy-provider",
-            "subComponents" : { },
-            "config" : {
-                "client-policy-executor-ids" : [ "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf", "47e818e3-f0d8-4a90-ace7-1a8b2362cec7" ],
-                "client-policy-condition-ids" : [ "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146" ]
-            }
-        } ],
-        "org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider" : [ {
-            "id" : "47e818e3-f0d8-4a90-ace7-1a8b2362cec7",
-            "name" : "SecureRequestObjectExecutor",
-            "providerId" : "secure-reqobj-executor",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf",
-            "name" : "SecureResponseTypeExecutor",
-            "providerId" : "secure-responsetype-executor",
-            "subComponents" : { },
-            "config" : { }
-        } ],
-        "org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider" : [ {
-            "id" : "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146",
-            "name" : "ClientRolesCondition",
-            "providerId" : "clientroles-condition",
-            "subComponents" : { },
-            "config" : {
-                "roles" : [ "sample-client-role" ]
-            }
+        ]
+    },
+    "clientProfiles" : {
+        "profiles" : [ {
+            "name" : "fapi-1-advanced-ID2",
+            "description" : "Client profile, which enforce clients to conform 'Financial-grade API Security Profile 1.0 - Part 2: Advanced' specification. It has some modifications to pass the FAPI testsuite, which is based on the ID2 specification draft",
+            "executors" : [ {
+                "executor" : "secure-session",
+                "configuration" : { }
+            }, {
+                "executor" : "confidential-client",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-client-authenticator",
+                "configuration" : {
+                    "allowed-client-authenticators" : [ "client-jwt", "client-x509" ],
+                    "default-client-authenticator" : "client-jwt"
+                }
+            }, {
+                "executor" : "secure-client-uris",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-request-object",
+                "configuration" : {
+                    "available-period" : "3600",
+                    "verify-nbf" : false
+                }
+            }, {
+                "executor" : "secure-response-type",
+                "configuration" : {
+                    "auto-configure" : true,
+                    "allow-token-response-type" : false
+                }
+            }, {
+                "executor" : "secure-signature-algorithm",
+                "configuration" : {
+                    "default-algorithm" : "PS256"
+                }
+            }, {
+                "executor" : "secure-signature-algorithm-signed-jwt",
+                "configuration" : {
+                    "require-client-assertion" : false
+                }
+            }, {
+                "executor" : "consent-required",
+                "configuration" : { }
+            }, {
+                "executor" : "holder-of-key-enforcer",
+                "configuration" : {
+                    "auto-configure" : true
+                }
+            } ]
+        } ]
+    },
+    "clientPolicies" : {
+        "policies" : [ {
+            "name" : "fapi-1-0-advanced-final-policy",
+            "description" : "The policy for FAPI 1.0 advanced security profile Final version",
+            "enabled" : true,
+            "conditions" : [ {
+                "condition" : "client-roles",
+                "configuration" : {
+                    "roles" : [ "sample-client-role" ]
+                }
+            } ],
+            "profiles" : [ "fapi-1-advanced-ID2" ]
         } ]
     },
     "roles" : {

--- a/keycloak/realm.json
+++ b/keycloak/realm.json
@@ -1221,6 +1221,9 @@
                 "executor" : "consent-required",
                 "configuration" : { }
             }, {
+                "executor" : "full-scope-disabled",
+                "configuration" : { }
+            }, {
                 "executor" : "holder-of-key-enforcer",
                 "configuration" : {
                     "auto-configure" : true

--- a/keycloak/realm.json
+++ b/keycloak/realm.json
@@ -1174,37 +1174,72 @@
                     ]
                 }
             }
-        ],
-        "org.keycloak.services.clientpolicy.ClientPolicyProvider" : [ {
-            "name" : "MyPolicy",
-            "providerId" : "client-policy-provider",
-            "subComponents" : { },
-            "config" : {
-                "client-policy-executor-ids" : [ "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf", "47e818e3-f0d8-4a90-ace7-1a8b2362cec7" ],
-                "client-policy-condition-ids" : [ "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146" ]
-            }
-        } ],
-        "org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider" : [ {
-            "id" : "47e818e3-f0d8-4a90-ace7-1a8b2362cec7",
-            "name" : "SecureRequestObjectExecutor",
-            "providerId" : "secure-reqobj-executor",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf",
-            "name" : "SecureResponseTypeExecutor",
-            "providerId" : "secure-responsetype-executor",
-            "subComponents" : { },
-            "config" : { }
-        } ],
-        "org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider" : [ {
-            "id" : "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146",
-            "name" : "ClientRolesCondition",
-            "providerId" : "clientroles-condition",
-            "subComponents" : { },
-            "config" : {
-                "roles" : [ "sample-client-role" ]
-            }
+        ]
+    },
+    "clientProfiles" : {
+        "profiles" : [ {
+            "name" : "fapi-1-advanced-ID2",
+            "description" : "Client profile, which enforce clients to conform 'Financial-grade API Security Profile 1.0 - Part 2: Advanced' specification. It has some modifications to pass the FAPI testsuite, which is based on the ID2 specification draft",
+            "executors" : [ {
+                "executor" : "secure-session",
+                "configuration" : { }
+            }, {
+                "executor" : "confidential-client",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-client-authenticator",
+                "configuration" : {
+                    "allowed-client-authenticators" : [ "client-jwt", "client-x509" ],
+                    "default-client-authenticator" : "client-jwt"
+                }
+            }, {
+                "executor" : "secure-client-uris",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-request-object",
+                "configuration" : {
+                    "available-period" : "3600",
+                    "verify-nbf" : false
+                }
+            }, {
+                "executor" : "secure-response-type",
+                "configuration" : {
+                    "auto-configure" : true,
+                    "allow-token-response-type" : false
+                }
+            }, {
+                "executor" : "secure-signature-algorithm",
+                "configuration" : {
+                    "default-algorithm" : "PS256"
+                }
+            }, {
+                "executor" : "secure-signature-algorithm-signed-jwt",
+                "configuration" : {
+                    "require-client-assertion" : false
+                }
+            }, {
+                "executor" : "consent-required",
+                "configuration" : { }
+            }, {
+                "executor" : "holder-of-key-enforcer",
+                "configuration" : {
+                    "auto-configure" : true
+                }
+            } ]
+        } ]
+    },
+    "clientPolicies" : {
+        "policies" : [ {
+            "name" : "fapi-1-0-advanced-final-policy",
+            "description" : "The policy for FAPI 1.0 advanced security profile Final version",
+            "enabled" : true,
+            "conditions" : [ {
+                "condition" : "client-roles",
+                "configuration" : {
+                    "roles" : [ "sample-client-role" ]
+                }
+            } ],
+            "profiles" : [ "fapi-1-advanced-ID2" ]
         } ]
     },
     "roles" : {


### PR DESCRIPTION
NOTE: This PR is still draft as it counts with latest Keycloak master. Hence it can't be merged as is. Once the Keycloak 14 is released, the PR will need to be updated (probably the change in `docker-compose.yml` will need to be removed entirely).

I am just sending the PR for the reference to point the configuration of client policies needed to pass with latest 4.1.11 conformance testsuite.

The Keycloak global profile can't be used as is due the known issue with the `nbf` claim in the request object. The FAPI Final specification mentions that `nbf` is required in the request object and must be verified, however the ID2 testsuite does not require it and uses the `request` objects without the `nbf` claim. Hopefully in some later versions, we will be able to directly use the  global profile `fapi-1-advanced` from Keycloak without need of any modifications to the profile.