### PR TITLE
Update conformance testsuite to latest Keycloak, version to 4.1.12 and support for online conformance testsuite

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 OPENID_GIT_URL=https://gitlab.com/openid/conformance-suite.git
-OPENID_GIT_TAG=${OPENID_GIT_TAG:-release-v4.1.11}
+OPENID_GIT_TAG=${OPENID_GIT_TAG:-release-v4.1.13}
 
 KEYCLOAK_REALM=test
 KEYCLOAK_USER=admin
@@ -9,7 +9,10 @@ KEYCLOAK_FQDN=as.keycloak-fapi.org
 RESOURCE_FQDN=rs.keycloak-fapi.org
 CONFORMANCE_SUITE_FQDN=conformance-suite.keycloak-fapi.org
 
+KEYCLOAK_FRONTEND_URL=https://${KEYCLOAK_FQDN}/auth
+KEYCLOAK_INTROSPECTION_ENDPOINT_FROM_API_GATEWAY=${KEYCLOAK_FRONTEND_URL}/realms/test/protocol/openid-connect/token/introspect
+
 AUTOMATE_TESTS=${AUTOMATE_TESTS:-true}
-KEYCLOAK_BASE_IMAGE=${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:12.0.4}
+KEYCLOAK_BASE_IMAGE=${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:14.0.0}
 KEYCLOAK_REALM_IMPORT_FILENAME=${KEYCLOAK_REALM_IMPORT_FILENAME:-realm.json}
 MVN_HOME=${MVN_HOME:-~/.m2}

--- a/api-gateway-nginx/fapi-verify.lua
+++ b/api-gateway-nginx/fapi-verify.lua
@@ -14,6 +14,8 @@ local res, err = nil
 if opts.introspection_endpoint ~= nil then
   opts.introspection_interval = 0
 
+  ngx.log(ngx.INFO, "Calling introspection endpoint on address: " .. opts.introspection_endpoint)
+
   -- call introspect for OAuth 2.0 Bearer Access Token validation
   res, err = openidc.introspect(opts)
 
@@ -39,7 +41,7 @@ end
 
 if res.cnf == nil or res.cnf["x5t#S256"] == nil then
   ngx.status = 401
-  ngx.say("no cnf.x5t#256 provided in access_token")
+  ngx.say("no cnf.x5t#S256 provided in access_token")
   ngx.exit(ngx.HTTP_UNAUTHORIZED)
 end
 
@@ -63,7 +65,7 @@ local b64 = require("ngx.base64")
 local encoded = b64.encode_base64url(digest)
 
 if encoded ~= res.cnf["x5t#S256"] then
-  ngx.log(ngx.ERR, "unmatch request client certificate and cnf.x5t#256 in access_token: " .. encoded .. " != " .. res.cnf["x5t#S256"])
+  ngx.log(ngx.ERR, "unmatch request client certificate and cnf.x5t#S256 in access_token: " .. encoded .. " != " .. res.cnf["x5t#S256"])
   ngx.exit(ngx.HTTP_UNAUTHORIZED)
 end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: ./load-balancer
     ports:
      - "443:443"
+     - "543:543"
     environment:
      - KEYCLOAK_FQDN=${KEYCLOAK_FQDN}
      - RESOURCE_FQDN=${RESOURCE_FQDN}
@@ -35,7 +36,7 @@ services:
      - ./https/server-key.pem:/etc/x509/https/tls.key
      - ./https/client-ca.pem:/etc/x509/https/client-ca.crt
 #     - ../bin/keycloak-conformance-test:/opt/jboss/keycloak
-    command: "-b 0.0.0.0 -Djboss.socket.binding.port-offset=1000 --debug -Dkeycloak.profile=preview"
+    command: "-b 0.0.0.0 -Djboss.socket.binding.port-offset=1000 --debug *:8787 -Dkeycloak.profile=preview -Dkeycloak.frontendUrl=${KEYCLOAK_FRONTEND_URL}"
   api_gateway_nginx:
     build:
       context: ./api-gateway-nginx
@@ -46,7 +47,7 @@ services:
      - ./https/ca.pem:/usr/local/share/ca-certificates/keycloak-fapi-ca.pem
     environment:
      - SERVER_NAME=${RESOURCE_FQDN}
-     - INTROSPECTION_ENDPOINT_URL=https://${KEYCLOAK_FQDN}/auth/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token/introspect
+     - INTROSPECTION_ENDPOINT_URL=${KEYCLOAK_INTROSPECTION_ENDPOINT_FROM_API_GATEWAY}
      # JWT access token veirfication can't pass reuse-authorisation-code case
      # - DISCOVERY_URL=https://${KEYCLOAK_FQDN}/auth/realms/${KEYCLOAK_REALM}/.well-known/openid-configuration
      - CLIENT_SECRET=2ef90464-b0fc-4e06-965d-19ef671a3e22

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,8 +1,8 @@
 ARG KEYCLOAK_BASE_IMAGE
 FROM ${KEYCLOAK_BASE_IMAGE}
 ARG KEYCLOAK_REALM_IMPORT_FILENAME
-# For FAPI-RW-8.5-2
-RUN sed -i -e "s/(key-manager=kcKeyManager)/(key-manager=kcKeyManager,protocols=[\"TLSv1.2\"],cipher-suite-filter=\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\")/" /opt/jboss/tools/cli/x509-keystore.cli
+# For FAPI-1-Final-Advanced, section 8.5
+RUN sed -i -e "s/(key-manager=kcKeyManager)/(key-manager=kcKeyManager,protocols=[\"TLSv1.2\"],cipher-suite-filter=\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_RSA_WITH_AES_256_GCM_SHA384\")/" /opt/jboss/tools/cli/x509-keystore.cli
 
 USER root
 

--- a/keycloak/realm-local.json
+++ b/keycloak/realm-local.json
@@ -1174,37 +1174,75 @@
                     ]
                 }
             }
-        ],
-        "org.keycloak.services.clientpolicy.ClientPolicyProvider" : [ {
-            "name" : "MyPolicy",
-            "providerId" : "client-policy-provider",
-            "subComponents" : { },
-            "config" : {
-                "client-policy-executor-ids" : [ "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf", "47e818e3-f0d8-4a90-ace7-1a8b2362cec7" ],
-                "client-policy-condition-ids" : [ "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146" ]
-            }
-        } ],
-        "org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider" : [ {
-            "id" : "47e818e3-f0d8-4a90-ace7-1a8b2362cec7",
-            "name" : "SecureRequestObjectExecutor",
-            "providerId" : "secure-reqobj-executor",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf",
-            "name" : "SecureResponseTypeExecutor",
-            "providerId" : "secure-responsetype-executor",
-            "subComponents" : { },
-            "config" : { }
-        } ],
-        "org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider" : [ {
-            "id" : "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146",
-            "name" : "ClientRolesCondition",
-            "providerId" : "clientroles-condition",
-            "subComponents" : { },
-            "config" : {
-                "roles" : [ "sample-client-role" ]
-            }
+        ]
+    },
+    "clientProfiles" : {
+        "profiles" : [ {
+            "name" : "fapi-1-rw-ID2",
+            "description" : "Client profile, which enforce clients to conform 'Financial-grade API - Part 2: Read and Write API Security Profile' specification. It has some modifications in comparison to fapi-1-advanced profile and it exists to pass the older FAPI testsuite plan, which is based on the FAPI RW ID2 specification draft (fapi-rw-id2-test-plan)",
+            "executors" : [ {
+                "executor" : "secure-session",
+                "configuration" : { }
+            }, {
+                "executor" : "confidential-client",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-client-authenticator",
+                "configuration" : {
+                    "allowed-client-authenticators" : [ "client-jwt", "client-x509" ],
+                    "default-client-authenticator" : "client-jwt"
+                }
+            }, {
+                "executor" : "secure-client-uris",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-request-object",
+                "configuration" : {
+                    "available-period" : "3600",
+                    "verify-nbf" : false
+                }
+            }, {
+                "executor" : "secure-response-type",
+                "configuration" : {
+                    "auto-configure" : true,
+                    "allow-token-response-type" : false
+                }
+            }, {
+                "executor" : "secure-signature-algorithm",
+                "configuration" : {
+                    "default-algorithm" : "PS256"
+                }
+            }, {
+                "executor" : "secure-signature-algorithm-signed-jwt",
+                "configuration" : {
+                    "require-client-assertion" : false
+                }
+            }, {
+                "executor" : "consent-required",
+                "configuration" : { }
+            }, {
+                "executor" : "full-scope-disabled",
+                "configuration" : { }
+            }, {
+                "executor" : "holder-of-key-enforcer",
+                "configuration" : {
+                    "auto-configure" : true
+                }
+            } ]
+        } ]
+    },
+    "clientPolicies" : {
+        "policies" : [ {
+            "name" : "fapi-1-0-policy",
+            "description" : "The policy for FAPI 1.0 security profile",
+            "enabled" : true,
+            "conditions" : [ {
+                "condition" : "client-roles",
+                "configuration" : {
+                    "roles" : [ "sample-client-role" ]
+                }
+            } ],
+            "profiles" : [ "fapi-1-rw-ID2" ]
         } ]
     },
     "roles" : {

--- a/keycloak/realm.json
+++ b/keycloak/realm.json
@@ -1174,37 +1174,75 @@
                     ]
                 }
             }
-        ],
-        "org.keycloak.services.clientpolicy.ClientPolicyProvider" : [ {
-            "name" : "MyPolicy",
-            "providerId" : "client-policy-provider",
-            "subComponents" : { },
-            "config" : {
-                "client-policy-executor-ids" : [ "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf", "47e818e3-f0d8-4a90-ace7-1a8b2362cec7" ],
-                "client-policy-condition-ids" : [ "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146" ]
-            }
-        } ],
-        "org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider" : [ {
-            "id" : "47e818e3-f0d8-4a90-ace7-1a8b2362cec7",
-            "name" : "SecureRequestObjectExecutor",
-            "providerId" : "secure-reqobj-executor",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "abad6ee9-6f4b-4e12-bc23-a5da2fdb6abf",
-            "name" : "SecureResponseTypeExecutor",
-            "providerId" : "secure-responsetype-executor",
-            "subComponents" : { },
-            "config" : { }
-        } ],
-        "org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider" : [ {
-            "id" : "047eb7c3-ba5f-45bc-9e27-9ca0d3ae5146",
-            "name" : "ClientRolesCondition",
-            "providerId" : "clientroles-condition",
-            "subComponents" : { },
-            "config" : {
-                "roles" : [ "sample-client-role" ]
-            }
+        ]
+    },
+    "clientProfiles" : {
+        "profiles" : [ {
+            "name" : "fapi-1-rw-ID2",
+            "description" : "Client profile, which enforce clients to conform 'Financial-grade API - Part 2: Read and Write API Security Profile' specification. It has some modifications in comparison to fapi-1-advanced profile and it exists to pass the older FAPI testsuite plan, which is based on the FAPI RW ID2 specification draft (fapi-rw-id2-test-plan)",
+            "executors" : [ {
+                "executor" : "secure-session",
+                "configuration" : { }
+            }, {
+                "executor" : "confidential-client",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-client-authenticator",
+                "configuration" : {
+                    "allowed-client-authenticators" : [ "client-jwt", "client-x509" ],
+                    "default-client-authenticator" : "client-jwt"
+                }
+            }, {
+                "executor" : "secure-client-uris",
+                "configuration" : { }
+            }, {
+                "executor" : "secure-request-object",
+                "configuration" : {
+                    "available-period" : "3600",
+                    "verify-nbf" : false
+                }
+            }, {
+                "executor" : "secure-response-type",
+                "configuration" : {
+                    "auto-configure" : true,
+                    "allow-token-response-type" : false
+                }
+            }, {
+                "executor" : "secure-signature-algorithm",
+                "configuration" : {
+                    "default-algorithm" : "PS256"
+                }
+            }, {
+                "executor" : "secure-signature-algorithm-signed-jwt",
+                "configuration" : {
+                    "require-client-assertion" : false
+                }
+            }, {
+                "executor" : "consent-required",
+                "configuration" : { }
+            }, {
+                "executor" : "full-scope-disabled",
+                "configuration" : { }
+            }, {
+                "executor" : "holder-of-key-enforcer",
+                "configuration" : {
+                    "auto-configure" : true
+                }
+            } ]
+        } ]
+    },
+    "clientPolicies" : {
+        "policies" : [ {
+            "name" : "fapi-1-0-policy",
+            "description" : "The policy for FAPI 1.0 security profile",
+            "enabled" : true,
+            "conditions" : [ {
+                "condition" : "client-roles",
+                "configuration" : {
+                    "roles" : [ "sample-client-role" ]
+                }
+            } ],
+            "profiles" : [ "fapi-1-rw-ID2" ]
         } ]
     },
     "roles" : {

--- a/load-balancer/Dockerfile
+++ b/load-balancer/Dockerfile
@@ -1,4 +1,8 @@
 FROM haproxy:1.9.8
 
-ADD haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+ADD *.cfg /tmp/
+
+# Switch the lines to use loadbalancer listening on two ports of single host.
+RUN /bin/sh -c "cp /tmp/haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg"
+# RUN /bin/sh -c "cp /tmp/haproxy_two-frontends.cfg /usr/local/etc/haproxy/haproxy.cfg"
 

--- a/load-balancer/haproxy_two-frontends.cfg
+++ b/load-balancer/haproxy_two-frontends.cfg
@@ -1,0 +1,91 @@
+# This configuration assume that haproxy loadbalancer will listen on two frontend ports 443 and 543.
+# This means that HTTP requests to the Keycloak server and "api-gateway-nginx" resource server both need to use same hostname for public access, but they differ just in the port.
+# This can be useful for the situation, when you want to run against official conformance testsuite from https://www.certification.openid.net, but you have only single hostname available
+# where both the AS (Keycloak) and the resource server (api-gateway-nginx) need to be accessible
+#
+# Example setup:
+#    Keycloak listening on: https://85-244-72-90.nip.io:543/auth
+#    Resource server listening on: https://85-244-72-90.nip.io:443/
+
+defaults
+  log stdout  format raw  local0  debug
+  option tcplog
+  timeout client 30s
+  timeout server 30s
+  timeout connect 5s
+
+frontend ft_ssl_vip_kc
+  bind *:543
+  mode tcp
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }
+
+  acl application_1 req_ssl_sni -i "${KEYCLOAK_FQDN}"
+  # acl application_2 req_ssl_sni -i "${RESOURCE_FQDN}"
+  # acl application_3 req_ssl_sni -i "${CONFORMANCE_SUITE_FQDN}"
+
+  use_backend bk_ssl_application_1 if application_1
+  # use_backend bk_ssl_application_2 if application_2
+  # use_backend bk_ssl_application_3 if application_3
+
+  default_backend bk_ssl_application_1
+
+frontend ft_ssl_vip_resource
+  bind *:443
+  mode tcp
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }
+
+  # acl application_1 req_ssl_sni -i "${KEYCLOAK_FQDN}"
+  acl application_2 req_ssl_sni -i "${KEYCLOAK_FQDN}"
+  acl application_3 req_ssl_sni -i "${CONFORMANCE_SUITE_FQDN}"
+
+  # use_backend bk_ssl_application_1 if application_1
+  use_backend bk_ssl_application_2 if application_2
+  use_backend bk_ssl_application_3 if application_3
+
+  default_backend bk_ssl_application_2
+
+backend bk_ssl_application_1
+  mode tcp
+
+  acl clienthello req_ssl_hello_type 1
+  acl serverhello rep_ssl_hello_type 2
+
+  # use tcp content accepts to detects ssl client and server hello.
+  tcp-request inspect-delay 5s
+  tcp-request content accept if clienthello
+
+  # no timeout on response inspect delay by default.
+  tcp-response content accept if serverhello
+
+  option ssl-hello-chk
+  server server1 keycloak:9443 check
+
+backend bk_ssl_application_2
+  mode tcp
+
+  #acl clienthello req_ssl_hello_type 1
+  #acl serverhello rep_ssl_hello_type 2
+
+  # use tcp content accepts to detects ssl client and server hello.
+  #tcp-request inspect-delay 5s
+  #tcp-request content accept if clienthello
+
+  # no timeout on response inspect delay by default.
+  #tcp-response content accept if serverhello
+
+  #option ssl-hello-chk
+  server server1 api_gateway_nginx:443 check
+
+backend bk_ssl_application_3
+  mode tcp
+
+  #acl clienthello req_ssl_hello_type 1
+
+  # use tcp content accepts to detects ssl client hello.
+  #tcp-request inspect-delay 5s
+  #tcp-request content accept if clienthello
+
+  #option ssl-hello-chk
+  server server1 httpd:8443 check


### PR DESCRIPTION
* Update realm JSON to pass with latest Keycloak master
 
* Update Keycloak dockerfile ciphers to match with FAPI 1 Advanced Final - section 8.5

* Update conformance testsuite to 4.1.12

* Add support and instructions for running against production conformance testsuite from www.certification.openid.net