### PR TITLE
Update conformance suite to v4.1.19

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 OPENID_GIT_URL=https://gitlab.com/openid/conformance-suite.git
-OPENID_GIT_TAG=${OPENID_GIT_TAG:-release-v4.1.17}
+OPENID_GIT_TAG=${OPENID_GIT_TAG:-release-v4.1.19}
 
 KEYCLOAK_REALM=test
 KEYCLOAK_USER=admin


### PR DESCRIPTION
Release Notes (v4.1.19)
* !1022 BrazilDCR: Fix MTLS token endpoint for the directory could be used instead of the server under test if the server under test had no `mtls_alias_endpoints` listed in it's openid-configuration
* !1022 Brazil: The suite now always requests the 3 permissions `ACCOUNTS_READ`, `ACCOUNTS_BALANCES_READ` and `RESOURCES_READ`. The server must return these 3 permissions (and no more).
* !1022 BrazilDCR: Old style certificates are no longer accepted; a new style certificate where the subjectdn contains a `UID` must be used for testing.

Release Notes (v4.1.18)
* #917 PAR tests no longer insist on `request_uri_parameter_supported` being true as per a revision to the PAR spec at some point.
* !1019 Remove 'not part of certification program' text from FAPI1Final RP tests, as certifications as now accepted for these as per https://openid.net/2021/06/23/openid-financial-grade-api-fapi-conformance-tests-released-for-final-fapi-1-0-parts-1-and-2-specifications/
* !1020 BrazilDCR: Tests now attempt to delete the client at the end, to avoid clients accumulating on the system being tests
* !1020 FAPIBrazil: Improved error message when an encryption key is missing from the server jwks
* !1020 The date is now included in the resultant filename when making a certification package to save users have to manually add it as per the submission instructions

Source: https://gitlab.com/openid/conformance-suite/-/tags

FYI : @tnorimat @mposolda @pedroigor