### PR TITLE
Refactor Keycloak configuration and scripts

### DIFF
--- a/oid4vci-deployment/config.yaml
+++ b/oid4vci-deployment/config.yaml
@@ -22,7 +22,7 @@ keycloak:
   # Keycloak installation directory (after unpack)
   install_dir: "${PROJECT_TOOLS_DIR}/keycloak-${KEYCLOAK_VERSION}"
   # Keycloak repository to clone
-  repo_url: "https://github.com/adorsys/keycloak-oid4vc.git"
+  # repo_url: "https://github.com/adorsys/keycloak-oid4vc.git"
   # Bootstrap admin credentials
   bootstrap:
     admin_username: "admin"

--- a/oid4vci-deployment/src/config/client-scope-config.json
+++ b/oid4vci-deployment/src/config/client-scope-config.json
@@ -89,12 +89,6 @@
         "protocol": "oid4vc",
         "protocolMapper": "oid4vc-subject-id-mapper",
         "config": {}
-      },
-      {
-        "name": "status-list-claim-mapper",
-        "protocol": "oid4vc",
-        "protocolMapper": "oid4vc-status-list-claim-mapper",
-        "config": {}
       }
     ]
   },
@@ -144,12 +138,6 @@
         "name": "id-mapper-kma",
         "protocol": "oid4vc",
         "protocolMapper": "oid4vc-subject-id-mapper",
-        "config": {}
-      },
-      {
-        "name": "status-list-claim-mapper-kma",
-        "protocol": "oid4vc",
-        "protocolMapper": "oid4vc-status-list-claim-mapper",
         "config": {}
       },
       {
@@ -460,12 +448,6 @@
         "name": "id-mapper-bsk",
         "protocol": "oid4vc",
         "protocolMapper": "oid4vc-subject-id-mapper",
-        "config": {}
-      },
-      {
-        "name": "status-list-claim-mapper-bsk",
-        "protocol": "oid4vc",
-        "protocolMapper": "oid4vc-status-list-claim-mapper",
         "config": {}
       }
     ]

--- a/oid4vci-deployment/src/config/realm_configs/keycloak-config-dev.json
+++ b/oid4vci-deployment/src/config/realm_configs/keycloak-config-dev.json
@@ -14,6 +14,9 @@
       "email": "fpo@mail.de",
       "createdTimestamp": 1732781977982,
       "enabled": true,
+      "realmRoles": [
+        "credential-offer-create"
+      ],
       "credentials": [
         {
           "id": "0a16e61d-c379-4f99-acdd-48aa57752e65",
@@ -147,14 +150,6 @@
           "config": {}
         },
         {
-          "id": "102b0638-6382-44de-ba29-79da000a4471",
-          "name": "status-list-claim-mapper",
-          "protocol": "oid4vc",
-          "protocolMapper": "oid4vc-status-list-claim-mapper",
-          "consentRequired": false,
-          "config": {}
-        },
-        {
           "id": "3559e36d-f013-4bc8-aa4c-1f937fa5d06b",
           "name": "nbf-oid4vc-issued-at-time-claim-mapper-identity_credential",
           "protocol": "oid4vc",
@@ -253,13 +248,6 @@
           "name": "id-mapper-kma",
           "protocol": "oid4vc",
           "protocolMapper": "oid4vc-subject-id-mapper",
-          "consentRequired": false,
-          "config": {}
-        },
-        {
-          "name": "status-list-claim-mapper-kma",
-          "protocol": "oid4vc",
-          "protocolMapper": "oid4vc-status-list-claim-mapper",
           "consentRequired": false,
           "config": {}
         },
@@ -506,14 +494,6 @@
           "name": "id-mapper-bsk",
           "protocol": "oid4vc",
           "protocolMapper": "oid4vc-subject-id-mapper",
-          "consentRequired": false,
-          "config": {}
-        },
-        {
-          "id": "bc96abbe-d539-4e4c-a134-4638d8b65f4e",
-          "name": "status-list-claim-mapper-bsk",
-          "protocol": "oid4vc",
-          "protocolMapper": "oid4vc-status-list-claim-mapper",
           "consentRequired": false,
           "config": {}
         },

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -182,7 +182,7 @@ fi
 # Validate OID4VCI configuration
 # -----------------------------------------------------------------------------
 log "Validating OID4VCI configuration..."
-response=$(curl -ks "$KEYCLOAK_ADMIN_ADDR/realms/$KEYCLOAK_REALM/.well-known/openid-credential-issuer")
+response=$(curl -ks "$KEYCLOAK_ADMIN_ADDR/.well-known/openid-credential-issuer/realms/$KEYCLOAK_REALM")
 [[ -z "$response" ]] && error "No response from Keycloak OIDC credential issuer endpoint."
 
 # Dynamically validate all credentials from the configuration file

--- a/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
+++ b/oid4vci-deployment/src/deployment/2.configure_user_4_account_client.sh
@@ -56,6 +56,28 @@ log "Setting password for user Francis..."
 success "Password ensured for Francis."
 
 # -----------------------------------------------------------------------------
+# Ensure 'credential-offer-create' realm role is assigned to Francis
+# This realm role grants permission to create credential offers.
+# -----------------------------------------------------------------------------
+log "Checking existence of realm role 'credential-offer-create'..."
+
+if "$KCADM" get roles/credential-offer-create -r "$KEYCLOAK_REALM" >/dev/null 2>&1; then
+  log "Assigning realm role 'credential-offer-create' to user Francis..."
+  FRANCIS_USER_ID=$("$KCADM" get users -r "$KEYCLOAK_REALM" -q username="$USERS_FRANCIS_NAME" --fields id | jq -r '.[0].id')
+  if [ -n "$FRANCIS_USER_ID" ] && [ "$FRANCIS_USER_ID" != "null" ]; then
+    "$KCADM" add-roles -r "$KEYCLOAK_REALM" \
+      --uid "$FRANCIS_USER_ID" \
+      --rolename credential-offer-create || \
+      warn "Failed to assign 'credential-offer-create' role to user Francis (it may already be assigned)."
+    success "Realm role 'credential-offer-create' assigned to Francis."
+  else
+    error "Could not find user Francis to assign realm role 'credential-offer-create'."
+  fi
+else
+  error "Realm role 'credential-offer-create' does not exist in realm '$KEYCLOAK_REALM'."
+fi
+
+# -----------------------------------------------------------------------------
 # Prepare user key proof header if not existent
 # -----------------------------------------------------------------------------
 if [ ! -f "$PROJECT_TARGET_DIR/user_key_proof_header.json" ]; then

--- a/oid4vci-deployment/src/deployment/setup-kc-oid4vci.sh
+++ b/oid4vci-deployment/src/deployment/setup-kc-oid4vci.sh
@@ -38,7 +38,7 @@ download_tarball() {
 # Clone custom Keycloak repository and build if needed
 # ---------------------------------------------------------------------------
 clone_and_build_keycloak() {
-    local repo_url="${KEYCLOAK_REPO_URL:-https://github.com/adorsys/keycloak-oid4vc.git}"
+    local repo_url="${KEYCLOAK_REPO_URL:-https://github.com/keycloak/keycloak.git}"
     local target_dir="$PROJECT_TARGET_DIR/$KEYCLOAK_OID4VCI_DIR"
     local build_artifact="$target_dir/quarkus/dist/target/keycloak-999.0.0-SNAPSHOT.tar.gz"
 


### PR DESCRIPTION
- Commented out the Keycloak repository URL in config.yaml.
- Removed unused status-list-claim-mapper entries from client-scope-config.json and keycloak-config-dev.json.
- Updated the OID4VCI deployment script to correct the Keycloak admin endpoint URL.
- Added logic to assign the 'credential-offer-create' realm role to user Francis in the user configuration script.
- Changed the default Keycloak repository URL in setup-kc-oid4vci.sh.

These changes streamline the configuration and enhance user role management.

Closes #877