### PR TITLE
Fix key provider registration and stop PID matching for oid4vci-deployment

### DIFF
--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -42,6 +42,11 @@ kcadm config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master \
 log "Creating realm '$KEYCLOAK_REALM' (if not exists)..."
 kcadm create realms -s realm="$KEYCLOAK_REALM" -s enabled=true >/dev/null 2>&1 || warn "Realm already exists; continuing."
 
+# Keycloak 26+ requires java-keystore under data/{realm}/
+mkdir -p "$KEYCLOAK_INSTALL_DIR/data/$KEYCLOAK_REALM"
+cp "${PROJECT_TARGET_DIR}/kc_keystore.pkcs12" "$KEYCLOAK_INSTALL_DIR/data/$KEYCLOAK_REALM/kc_keystore.pkcs12"
+KEYSTORE_PATH="kc_keystore.pkcs12"
+
 # -----------------------------------------------------------------------------
 # Configure key providers
 # -----------------------------------------------------------------------------
@@ -76,7 +81,8 @@ register_key_provider() {
   local json_content="$2"
 
   local exists
-  exists=$(kcadm get components -r "$KEYCLOAK_REALM" --fields name \
+  # Request id+name: --fields name alone omits .id and made the check always miss.
+  exists=$(kcadm get components -r "$KEYCLOAK_REALM" --fields id,name \
             | jq -r --arg n "$name" '.[]? | select(.name == $n) | .id' | head -n1)
 
   if [[ -n "$exists" ]]; then
@@ -84,9 +90,11 @@ register_key_provider() {
     return 0
   fi
 
-  if ! echo "$json_content" | kcadm create components -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1; then
-    warn "Failed to register key provider '$name'; it already exists."
+  local err
+  if ! err=$(echo "$json_content" | kcadm create components -r "$KEYCLOAK_REALM" -o -f - 2>&1); then
+    error "Failed to register key provider '$name': $err"
   fi
+  success "Registered key provider '$name'."
 }
 
 # ECDSA

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -42,7 +42,9 @@ kcadm config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master \
 log "Creating realm '$KEYCLOAK_REALM' (if not exists)..."
 kcadm create realms -s realm="$KEYCLOAK_REALM" -s enabled=true >/dev/null 2>&1 || warn "Realm already exists; continuing."
 
-# Keycloak 26+ requires java-keystore under data/{realm}/
+# Keycloak 26+ restricts java-keystore files to data/{realm}/ (relative paths resolve there).
+# Introduced: https://github.com/keycloak/keycloak/commit/9697e1aa5d1ec58d759e4119fb02b876b3392845
+# Source (26.7.0): https://github.com/keycloak/keycloak/blob/26.7.0/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java#L142-L149
 mkdir -p "$KEYCLOAK_INSTALL_DIR/data/$KEYCLOAK_REALM"
 cp "${PROJECT_TARGET_DIR}/kc_keystore.pkcs12" "$KEYCLOAK_INSTALL_DIR/data/$KEYCLOAK_REALM/kc_keystore.pkcs12"
 KEYSTORE_PATH="kc_keystore.pkcs12"

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -368,14 +368,16 @@ inject_environment_variables() {
 # Keycloak Process Management
 # -----------------------------------------------------------------------------
 get_keycloak_pid() {
-    local pid="" p exe
-    for p in $(pgrep -f 'io.quarkus.bootstrap.runner.QuarkusEntryPoint' 2>/dev/null || true); do
-        exe="$(readlink "/proc/$p/exe" 2>/dev/null || true)"
-        if [[ "$exe" == *"/java"* ]]; then
-            pid="$p"
-            break
+    local pid
+    if command -v pgrep &>/dev/null; then
+        pid=$(pgrep -f keycloak | head -n1 || true)
+    else
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            pid=$(ps aux | grep -i '[q]uarkus' | awk 'NR==1{print $2}' || true)
+        else
+            pid=$(ps aux | grep -i '[k]eycloak' | awk 'NR==1{print $2}' || true)
         fi
-    done
+    fi
     echo "$pid"
 }
 

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -368,16 +368,14 @@ inject_environment_variables() {
 # Keycloak Process Management
 # -----------------------------------------------------------------------------
 get_keycloak_pid() {
-    local pid
-    if command -v pgrep &>/dev/null; then
-        pid=$(pgrep -f keycloak | head -n1 || true)
-    else
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            pid=$(ps aux | grep -i '[q]uarkus' | awk 'NR==1{print $2}' || true)
-        else
-            pid=$(ps aux | grep -i '[k]eycloak' | awk 'NR==1{print $2}' || true)
+    local pid="" p exe
+    for p in $(pgrep -f 'io.quarkus.bootstrap.runner.QuarkusEntryPoint' 2>/dev/null || true); do
+        exe="$(readlink "/proc/$p/exe" 2>/dev/null || true)"
+        if [[ "$exe" == *"/java"* ]]; then
+            pid="$p"
+            break
         fi
-    fi
+    done
     echo "$pid"
 }
 


### PR DESCRIPTION
## Summary
- Fix OID4VCI key provider registration: place the java-keystore under `data/{realm}/`, correct the `kcadm --fields id,name` existence check, and surface real create errors instead of a hardcoded "already exists" warning.
- Fix unreliable Keycloak stop: match only the Keycloak JVM (`QuarkusEntryPoint` + `java` exe) instead of broad `pgrep -f keycloak`.

Closes #1038

## Test plan
- [ ] `./keycloak-ssi.sh setup` then `KEYCLOAK_SSI_IN_CONTAINER=1 ./keycloak-ssi.sh config` on 26.7 — ECDSA/RSA/RSA-enc providers register successfully
- [ ] Re-run `config` — providers are skipped as already existing (idempotent)
- [ ] `./keycloak-ssi.sh stop` targets the Keycloak JVM, not unrelated processes