### PR TITLE
Place Keycloak keystore under data/<realm> for 26.6.4+

### DIFF
--- a/oid4vci-deployment/config.yaml
+++ b/oid4vci-deployment/config.yaml
@@ -33,12 +33,16 @@ keycloak:
     admin_password: "admin"
   # Keycloak realm
   realm: "oid4vc-vci"
-  # Enable pre-authorized code flow. In newer Keycloak versions, the pre-auth code flow
-  # must be explicitly enabled to be used for credential issuance. In older versions,
-  # it is enabled by default and this must be set to false.
+  # Enable pre-authorized code flow. In newer Keycloak versions (26.7+), the pre-auth code
+  # flow must be explicitly enabled. On older versions it is on by default — keep false there
+  # or setup fails with an unrecognized feature.
   enable_preauth_code: false
-  # Enable credential-offer-create role for users
+  # Assign credential-offer-create realm role (needed for mock FE QR / create-credential-offer).
+  # Applies on all supported Keycloak versions (role only; does not toggle KC features).
   enable_credential_offer_create: false
+  # Enable oid4vc-vci-rest-credential-offer (Keycloak 26.7+ create-credential-offer endpoint).
+  # Ignored on older versions where the feature flag does not exist.
+  enable_rest_credential_offer: false
 
 # -----------------------------------------------------------------------------
 # Keycloak container image
@@ -51,10 +55,9 @@ keycloak_image:
 # Keystore configuration
 # -----------------------------------------------------------------------------
 keystore:
-  # Keycloak keystore file path
-  # Default /opt/keycloak/target/kc_keystore.pkcs12 (Docker container path)
-  # 👉 Change this to "${PROJECT_TARGET_DIR}/kc_keystore.pkcs12" when running Keycloak on the host machine.
-  path: "/opt/keycloak/target/kc_keystore.pkcs12"
+  # Realm keystore under ${kc.home.dir}/data/<realm>/ (required for Keycloak 26.6.4+; valid on older versions).
+  # Single path for host and Docker: KEYCLOAK_INSTALL_DIR is the Keycloak home (host install or image install).
+  path: "${KEYCLOAK_INSTALL_DIR}/data/${KEYCLOAK_REALM}/kc_keystore.pkcs12"
   # Keystore type
   type: "PKCS12"
   # Keystore password

--- a/oid4vci-deployment/config.yaml
+++ b/oid4vci-deployment/config.yaml
@@ -33,10 +33,11 @@ keycloak:
     admin_password: "admin"
   # Keycloak realm
   realm: "oid4vc-vci"
-  # Enable pre-authorized code flow. In newer Keycloak versions (26.7+), the pre-auth code
-  # flow must be explicitly enabled. On older versions it is on by default 
+  # Enable pre-authorized code flow. In newer Keycloak versions, the pre-auth code flow
+  # must be explicitly enabled to be used for credential issuance. In older versions,
+  # it is enabled by default and this must be set to false.
   enable_preauth_code: false
-  # Assign credential-offer-create realm role.
+  # Enable credential-offer-create role for users
   enable_credential_offer_create: false
   # Enable oid4vc-vci-rest-credential-offer (Keycloak 26.6.4+ create-credential-offer endpoint).
   enable_rest_credential_offer: false

--- a/oid4vci-deployment/config.yaml
+++ b/oid4vci-deployment/config.yaml
@@ -34,14 +34,11 @@ keycloak:
   # Keycloak realm
   realm: "oid4vc-vci"
   # Enable pre-authorized code flow. In newer Keycloak versions (26.7+), the pre-auth code
-  # flow must be explicitly enabled. On older versions it is on by default — keep false there
-  # or setup fails with an unrecognized feature.
+  # flow must be explicitly enabled. On older versions it is on by default 
   enable_preauth_code: false
-  # Assign credential-offer-create realm role (needed for mock FE QR / create-credential-offer).
-  # Applies on all supported Keycloak versions (role only; does not toggle KC features).
+  # Assign credential-offer-create realm role.
   enable_credential_offer_create: false
-  # Enable oid4vc-vci-rest-credential-offer (Keycloak 26.7+ create-credential-offer endpoint).
-  # Ignored on older versions where the feature flag does not exist.
+  # Enable oid4vc-vci-rest-credential-offer (Keycloak 26.6.4+ create-credential-offer endpoint).
   enable_rest_credential_offer: false
 
 # -----------------------------------------------------------------------------

--- a/oid4vci-deployment/docker-compose.yml
+++ b/oid4vci-deployment/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - db_data:/var/lib/postgresql
 
   app:
-    image: ${KEYCLOAK_IMAGE_REGISTRY:-quay.io/keycloak/keycloak}:${KEYCLOAK_IMAGE_TAG:-26.5.0}
+    image: ${KEYCLOAK_IMAGE_REGISTRY:-quay.io/keycloak/keycloak}:${KEYCLOAK_IMAGE_TAG:-26.7.0}
     environment:
       # Database configuration
       KC_DB: postgres
@@ -32,6 +32,8 @@ services:
 
     volumes:
       - ./target:/opt/keycloak/target
+      # Realm keystores under ${kc.home.dir}/data/<realm>/ (Keycloak 26.6.4+)
+      - ./target/keycloak-data:/opt/keycloak/data
 
     command:
       - start
@@ -54,8 +56,8 @@ services:
       WORK_DIR: /workspace
       KEYCLOAK_SSI_IN_CONTAINER: "1"
       COMPOSE_PROJECT_NAME: "oid4vci-deployment"
-      # Host project root path (used when Keycloak runs on host but CLI runs in container)
-      HOST_WORK_DIR: ${PWD}
+      # Host project root (CLI remaps /workspace → host path for Keycloak)
+      HOST_WORK_DIR: ${HOST_WORK_DIR:-${PWD}}
     volumes:
       - .:/workspace
       - ./target:/workspace/target

--- a/oid4vci-deployment/docker-entrypoint.sh
+++ b/oid4vci-deployment/docker-entrypoint.sh
@@ -25,5 +25,4 @@ export KC_BOOTSTRAP_ADMIN_PASSWORD="${KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD}"
 
 cd "$KEYCLOAK_INSTALL_DIR"
 
-# Features come from config.yaml (KEYCLOAK_FEATURES), including 26.7+ flags when enabled.
-eval "exec bin/kc.sh $START_COMMAND ${DATABASE_OPTS:-} --features=${KEYCLOAK_FEATURES}"
+eval "exec bin/kc.sh $START_COMMAND $DATABASE_OPTS --features=oid4vc-vci"

--- a/oid4vci-deployment/docker-entrypoint.sh
+++ b/oid4vci-deployment/docker-entrypoint.sh
@@ -25,4 +25,5 @@ export KC_BOOTSTRAP_ADMIN_PASSWORD="${KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD}"
 
 cd "$KEYCLOAK_INSTALL_DIR"
 
-eval "exec bin/kc.sh $START_COMMAND $DATABASE_OPTS --features=oid4vc-vci"
+# Features come from config.yaml (KEYCLOAK_FEATURES), including 26.7+ flags when enabled.
+eval "exec bin/kc.sh $START_COMMAND ${DATABASE_OPTS:-} --features=${KEYCLOAK_FEATURES}"

--- a/oid4vci-deployment/docs/MIGRATION_26.7.md
+++ b/oid4vci-deployment/docs/MIGRATION_26.7.md
@@ -14,7 +14,7 @@ Keycloak **26.7.0** keeps OID4VCI experimental but moves pre-authorized code and
    Set `keycloak.enable_rest_credential_offer: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-rest-credential-offer`. Without it, the `create-credential-offer` endpoint is disabled on 26.7+.
 
 4. **Grant the `credential-offer-create` role (optional)**  
-   Set `keycloak.enable_credential_offer_create: true` to assign the `credential-offer-create` realm role to the demo user. This is independent of the REST feature flag above (role ≠ feature).
+   Set `keycloak.enable_credential_offer_create: true` to assign the `credential-offer-create` realm role to the demo user.
 
 5. **Grant verifiable credentials to the demo user**  
    On 26.7+, issuance requires an explicit per-user VC grant for each credential scope (IdentityCredential, SteuerberaterCredential, KMACredential). Grant these in the Admin Console for the demo user, or via the Admin API if you automate setup elsewhere. The `keycloak-ssi config` script does **not** perform this step.

--- a/oid4vci-deployment/docs/MIGRATION_26.7.md
+++ b/oid4vci-deployment/docs/MIGRATION_26.7.md
@@ -13,13 +13,10 @@ Keycloak **26.7.0** keeps OID4VCI experimental but moves pre-authorized code and
 3. **Enable REST credential-offer creation**  
    Set `keycloak.enable_rest_credential_offer: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-rest-credential-offer`. Without it, the `create-credential-offer` endpoint is disabled on 26.7+.
 
-4. **Grant the `credential-offer-create` role (optional)**  
-   Set `keycloak.enable_credential_offer_create: true` to assign the `credential-offer-create` realm role to the demo user.
-
-5. **Grant verifiable credentials to the demo user**  
+4. **Grant verifiable credentials to the demo user** 
    On 26.7+, issuance requires an explicit per-user VC grant for each credential scope (IdentityCredential, SteuerberaterCredential, KMACredential). Grant these in the Admin Console for the demo user, or via the Admin API if you automate setup elsewhere. The `keycloak-ssi config` script does **not** perform this step.
 
-6. **Recreate Keycloak after flag changes**  
+5. **Recreate Keycloak after flag changes**  
    Restart or recreate the Keycloak container so `KC_FEATURES` picks up the new flags.
 
 ### Sample `config.override.yaml`

--- a/oid4vci-deployment/docs/MIGRATION_26.7.md
+++ b/oid4vci-deployment/docs/MIGRATION_26.7.md
@@ -11,12 +11,15 @@ Keycloak **26.7.0** keeps OID4VCI experimental but moves pre-authorized code and
    Set `keycloak.enable_preauth_code: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-preauth-code`.
 
 3. **Enable REST credential-offer creation**  
-   Set `keycloak.enable_credential_offer_create: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-rest-credential-offer`. Without it, `create-credential-offer` is disabled on 26.7+.
+   Set `keycloak.enable_rest_credential_offer: true` so `KEYCLOAK_FEATURES` includes `oid4vc-vci-rest-credential-offer`. Without it, the `create-credential-offer` endpoint is disabled on 26.7+.
 
-4. **Grant verifiable credentials to the demo user**  
+4. **Grant the `credential-offer-create` role (optional)**  
+   Set `keycloak.enable_credential_offer_create: true` to assign the `credential-offer-create` realm role to the demo user. This is independent of the REST feature flag above (role ≠ feature).
+
+5. **Grant verifiable credentials to the demo user**  
    On 26.7+, issuance requires an explicit per-user VC grant for each credential scope (IdentityCredential, SteuerberaterCredential, KMACredential). Grant these in the Admin Console for the demo user, or via the Admin API if you automate setup elsewhere. The `keycloak-ssi config` script does **not** perform this step.
 
-5. **Recreate Keycloak after flag changes**  
+6. **Recreate Keycloak after flag changes**  
    Restart or recreate the Keycloak container so `KC_FEATURES` picks up the new flags.
 
 ### Sample `config.override.yaml`
@@ -24,6 +27,7 @@ Keycloak **26.7.0** keeps OID4VCI experimental but moves pre-authorized code and
 ```yaml
 keycloak:
   enable_preauth_code: true
+  enable_rest_credential_offer: true
   enable_credential_offer_create: true
 ```
 

--- a/oid4vci-deployment/keycloak-ssi.sh
+++ b/oid4vci-deployment/keycloak-ssi.sh
@@ -153,12 +153,11 @@ run_in_cli_container_if_needed() {
             [[ -f "$override_file" ]] && config_files+=("$override_file")
             rm -f "$env_file"
             export_yaml_as_env "${config_files[@]}" > "$env_file"
-            # Forward all original arguments into the cli service, using the env file.
-            # Build command array to properly forward all arguments.
-            local compose_args=("--env-file" "$env_file" "run" "--rm" "cli")
-            # Append all original arguments
+            # HOST_WORK_DIR must be the host project root so KEYSTORE_PATH can be remapped
+            # from /workspace/... to the path Keycloak on the host actually sees.
+            # Pass -e explicitly: VAR=value eval '...' does not reliably forward env to docker compose.
+            local compose_args=("--env-file" "$env_file" "run" "--rm" "-e" "HOST_WORK_DIR=$WORK_DIR" "cli")
             compose_args+=("$@")
-            # Execute with proper environment (use eval like cmd_compose does)
             COMPOSE_PROJECT_NAME="$project_name" eval "$DOCKER_COMPOSE_CMD" "${compose_args[@]}"
             exit $?
             ;;

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -16,13 +16,11 @@ init_script
 # -----------------------------------------------------------------------------
 # Ensure Keycloak is running
 # -----------------------------------------------------------------------------
-# PID detection fails from the CLI container (different PID namespace). Fall back to HTTP.
 keycloak_pid="$(get_keycloak_pid || true)"
-if [[ -z "${keycloak_pid:-}" ]] \
-    && ! curl -k -s -o /dev/null -w '' "$KEYCLOAK_ADMIN_ADDR/realms/master" 2>/dev/null; then
-  error "Keycloak is not running. Start Keycloak using 'keycloak-ssi setup -d' or 'keycloak-ssi compose up -d' first."
+if [[ -z "${keycloak_pid:-}" ]]; then
+  error "Keycloak is not running. Start Keycloak using '0.start-kc-oid4vci.sh' first."
 fi
-log "Keycloak is running."
+log "Keycloak is running (PID: $keycloak_pid)."
 
 # -----------------------------------------------------------------------------
 # Authenticate admin

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -16,11 +16,13 @@ init_script
 # -----------------------------------------------------------------------------
 # Ensure Keycloak is running
 # -----------------------------------------------------------------------------
+# PID detection fails from the CLI container (different PID namespace). Fall back to HTTP.
 keycloak_pid="$(get_keycloak_pid || true)"
-if [[ -z "${keycloak_pid:-}" ]]; then
-  error "Keycloak is not running. Start Keycloak using '0.start-kc-oid4vci.sh' first."
+if [[ -z "${keycloak_pid:-}" ]] \
+    && ! curl -k -s -o /dev/null -w '' "$KEYCLOAK_ADMIN_ADDR/realms/master" 2>/dev/null; then
+  error "Keycloak is not running. Start Keycloak using 'keycloak-ssi setup -d' or 'keycloak-ssi compose up -d' first."
 fi
-log "Keycloak is running (PID: $keycloak_pid)."
+log "Keycloak is running."
 
 # -----------------------------------------------------------------------------
 # Authenticate admin

--- a/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
+++ b/oid4vci-deployment/src/deployment/1.oid4vci_test_deployment.sh
@@ -14,19 +14,15 @@ source "$WORK_DIR/src/utils/helper.sh"
 init_script
 
 # -----------------------------------------------------------------------------
-# Ensure KEYCLOAK_INSTALL_DIR is resolved if KEYCLOAK_VERSION is "latest"
-# This is needed so the kcadm helper can find the local Keycloak install
-# -----------------------------------------------------------------------------
-ensure_keycloak_install_dir_resolved
-
-# -----------------------------------------------------------------------------
 # Ensure Keycloak is running
 # -----------------------------------------------------------------------------
+# PID detection fails from the CLI container (different PID namespace). Fall back to HTTP.
 keycloak_pid="$(get_keycloak_pid || true)"
-if [[ -z "${keycloak_pid:-}" ]]; then
-  error "Keycloak is not running. Start Keycloak using '0.start-kc-oid4vci.sh' first."
+if [[ -z "${keycloak_pid:-}" ]] \
+    && ! curl -k -s -o /dev/null -w '' "$KEYCLOAK_ADMIN_ADDR/realms/master" 2>/dev/null; then
+  error "Keycloak is not running. Start Keycloak using 'keycloak-ssi setup -d' or 'keycloak-ssi compose up -d' first."
 fi
-log "Keycloak is running (PID: $keycloak_pid)."
+log "Keycloak is running."
 
 # -----------------------------------------------------------------------------
 # Authenticate admin
@@ -76,16 +72,17 @@ register_key_provider() {
   local json_content="$2"
 
   local exists
-  exists=$(kcadm get components -r "$KEYCLOAK_REALM" --fields name \
+  exists=$(kcadm get components -r "$KEYCLOAK_REALM" --fields id,name \
             | jq -r --arg n "$name" '.[]? | select(.name == $n) | .id' | head -n1)
 
-  if [[ -n "$exists" ]]; then
-    warn "Key provider '$name' already exists (ID: $exists); skipping."
+  if [[ -n "$exists" && "$exists" != "null" ]]; then
+    warn "Key provider '$name' already exists; skipping."
     return 0
   fi
 
-  if ! echo "$json_content" | kcadm create components -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1; then
-    warn "Failed to register key provider '$name'; it already exists."
+  local create_out
+  if ! create_out=$(echo "$json_content" | kcadm create components -r "$KEYCLOAK_REALM" -o -f - 2>&1); then
+    error "Failed to register key provider '$name': $create_out"
   fi
 }
 

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -168,9 +168,7 @@ export_yaml_as_env() {
     [[ -n "${ISSUER_ENDPOINTS_FRONTEND:-}" ]] && export ISSUER_FRONTEND_URL="${ISSUER_ENDPOINTS_FRONTEND}"
     [[ -n "${CLIENTS_TEST_CLIENT:-}" ]] && export TEST_CLIENT_URL="${CLIENTS_TEST_CLIENT}"
     
-    # Collect features to start Keycloak with.
-    # On Keycloak < 26.7 keep enable_preauth_code / enable_rest_credential_offer false
-    # (those feature names do not exist and will abort startup).
+    # Collect features to start Keycloak with
     KEYCLOAK_FEATURES="${KEYCLOAK_FEATURES:-oid4vc-vci}"
 
     [[ "${KEYCLOAK_ENABLE_PREAUTH_CODE:-}" == "true" ]] && \
@@ -179,11 +177,9 @@ export_yaml_as_env() {
         KEYCLOAK_FEATURES="$KEYCLOAK_FEATURES,oid4vc-vci-rest-credential-offer"
     export KEYCLOAK_FEATURES
 
-    # Resolve "latest" then keep keystore.path under the concrete install dir (from config).
+    # Resolve "latest" then keep keystore.path under the concrete install dir.
     ensure_keycloak_install_dir_resolved
 
-    # Remap only Keycloak home for registration — config owns the data/<realm>/ layout.
-    # No user switching between host/docker paths: config.yaml stays SSOT.
     if [[ -n "${KEYSTORE_PATH:-}" && -n "${KEYCLOAK_INSTALL_DIR:-}" ]]; then
         local docker_compose_cmd
         docker_compose_cmd="$(detect_docker_compose 2>/dev/null || echo "")"
@@ -198,10 +194,10 @@ export_yaml_as_env() {
         fi
 
         if [[ "$keycloak_in_docker" == "true" ]]; then
-            # Official compose image: kc.home.dir=/opt/keycloak (./target/keycloak-data → /opt/keycloak/data)
+            # Keycloak in docker: use container path
             export KEYSTORE_PATH="/opt/keycloak/data/${data_rel}"
         elif [[ -n "${KEYCLOAK_SSI_IN_CONTAINER:-}" ]]; then
-            # CLI container + Keycloak on host: map /workspace → host project root
+            # CLI in container, Keycloak on host: convert container path to host path
             local host_project_root="${HOST_WORK_DIR:-}"
             if [[ -z "$host_project_root" ]] && command -v docker &>/dev/null && [[ -S /var/run/docker.sock ]]; then
                 local container_name
@@ -217,7 +213,6 @@ export_yaml_as_env() {
                 warn "Cannot determine host path for KEYSTORE_PATH. Set HOST_WORK_DIR when running the CLI."
             fi
         fi
-        # else: host setup/config — KEYSTORE_PATH already under KEYCLOAK_INSTALL_DIR/data/<realm>/
     fi
 }
 
@@ -494,7 +489,7 @@ ensure_directory_exists() {
 ensure_keycloak_crypto_materials() {
     # Ensure PROJECT_TARGET_DIR is set (fallback to WORK_DIR/target if not configured)
     PROJECT_TARGET_DIR="${PROJECT_TARGET_DIR:-${WORK_DIR:-/tmp}/target}"
-    # Resolves "latest" and rebinds keystore.path under KEYCLOAK_INSTALL_DIR from config.
+    # Resolves "latest" and rebinds keystore.path under KEYCLOAK_INSTALL_DIR.
     ensure_keycloak_install_dir_resolved
 
     if [[ -z "${KEYCLOAK_INSTALL_DIR:-}" ]]; then

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -154,6 +154,9 @@ export_yaml_as_env() {
             "keycloak.enable_credential_offer_create")
                 export KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE="$resolved_value"
                 ;;
+            "keycloak.enable_rest_credential_offer")
+                export KEYCLOAK_ENABLE_REST_CREDENTIAL_OFFER="$resolved_value"
+                ;;
         esac
     done <<< "$raw_props_output"
     set -u # Restore 'nounset'
@@ -165,21 +168,28 @@ export_yaml_as_env() {
     [[ -n "${ISSUER_ENDPOINTS_FRONTEND:-}" ]] && export ISSUER_FRONTEND_URL="${ISSUER_ENDPOINTS_FRONTEND}"
     [[ -n "${CLIENTS_TEST_CLIENT:-}" ]] && export TEST_CLIENT_URL="${CLIENTS_TEST_CLIENT}"
     
-    # Collect features to start Keycloak with
+    # Collect features to start Keycloak with.
+    # On Keycloak < 26.7 keep enable_preauth_code / enable_rest_credential_offer false
+    # (those feature names do not exist and will abort startup).
     KEYCLOAK_FEATURES="${KEYCLOAK_FEATURES:-oid4vc-vci}"
-    [[ "${KEYCLOAK_ENABLE_PREAUTH_CODE:-}" == "true" ]] && KEYCLOAK_FEATURES="$KEYCLOAK_FEATURES,oid4vc-vci-preauth-code"
-    # Keycloak 26.7+ gates create-credential-offer behind oid4vc-vci-rest-credential-offer.
-    [[ "${KEYCLOAK_ENABLE_CREDENTIAL_OFFER_CREATE:-}" == "true" ]] && \
+
+    [[ "${KEYCLOAK_ENABLE_PREAUTH_CODE:-}" == "true" ]] && \
+        KEYCLOAK_FEATURES="$KEYCLOAK_FEATURES,oid4vc-vci-preauth-code"
+    [[ "${KEYCLOAK_ENABLE_REST_CREDENTIAL_OFFER:-}" == "true" ]] && \
         KEYCLOAK_FEATURES="$KEYCLOAK_FEATURES,oid4vc-vci-rest-credential-offer"
     export KEYCLOAK_FEATURES
 
-    # Adjust KEYSTORE_PATH based on where Keycloak is running
-    if [[ -n "${KEYSTORE_PATH:-}" ]]; then
+    # Resolve "latest" then keep keystore.path under the concrete install dir (from config).
+    ensure_keycloak_install_dir_resolved
+
+    # Remap only Keycloak home for registration — config owns the data/<realm>/ layout.
+    # No user switching between host/docker paths: config.yaml stays SSOT.
+    if [[ -n "${KEYSTORE_PATH:-}" && -n "${KEYCLOAK_INSTALL_DIR:-}" ]]; then
         local docker_compose_cmd
         docker_compose_cmd="$(detect_docker_compose 2>/dev/null || echo "")"
         local keycloak_in_docker=false
+        local data_rel="${KEYSTORE_PATH#*/data/}"
 
-        # Check if Keycloak is running in Docker (app container)
         if [[ -n "$docker_compose_cmd" ]]; then
             if eval "$docker_compose_cmd" ps app --format json 2>/dev/null | grep -q '"State":"running"' 2>/dev/null || \
                 eval "$docker_compose_cmd" ps app 2>/dev/null | grep -q "app.*Up" 2>/dev/null; then
@@ -188,13 +198,11 @@ export_yaml_as_env() {
         fi
 
         if [[ "$keycloak_in_docker" == "true" ]]; then
-            # Keycloak in Docker: use container path
-            export KEYSTORE_PATH="/opt/keycloak/target/kc_keystore.pkcs12"
+            # Official compose image: kc.home.dir=/opt/keycloak (./target/keycloak-data → /opt/keycloak/data)
+            export KEYSTORE_PATH="/opt/keycloak/data/${data_rel}"
         elif [[ -n "${KEYCLOAK_SSI_IN_CONTAINER:-}" ]]; then
-            # CLI in container, Keycloak on host: convert container path to host path
+            # CLI container + Keycloak on host: map /workspace → host project root
             local host_project_root="${HOST_WORK_DIR:-}"
-
-            # Try to detect host path from Docker volume mount if HOST_WORK_DIR not set
             if [[ -z "$host_project_root" ]] && command -v docker &>/dev/null && [[ -S /var/run/docker.sock ]]; then
                 local container_name
                 container_name="$(hostname 2>/dev/null || echo "")"
@@ -203,13 +211,13 @@ export_yaml_as_env() {
                         jq -r '.[0].Mounts[] | select(.Destination == "/workspace") | .Source' 2>/dev/null | head -1 || echo "")
                 fi
             fi
-
-            if [[ -n "$host_project_root" ]]; then
-                export KEYSTORE_PATH="$host_project_root/target/kc_keystore.pkcs12"
-            else
-                warn "Cannot determine host path for KEYSTORE_PATH. Set HOST_WORK_DIR in docker-compose.yml."
+            if [[ -n "$host_project_root" && -n "${WORK_DIR:-}" && "$KEYSTORE_PATH" == "$WORK_DIR"* ]]; then
+                export KEYSTORE_PATH="${host_project_root}${KEYSTORE_PATH#"$WORK_DIR"}"
+            elif [[ -z "$host_project_root" ]]; then
+                warn "Cannot determine host path for KEYSTORE_PATH. Set HOST_WORK_DIR when running the CLI."
             fi
         fi
+        # else: host setup/config — KEYSTORE_PATH already under KEYCLOAK_INSTALL_DIR/data/<realm>/
     fi
 }
 
@@ -486,7 +494,23 @@ ensure_directory_exists() {
 ensure_keycloak_crypto_materials() {
     # Ensure PROJECT_TARGET_DIR is set (fallback to WORK_DIR/target if not configured)
     PROJECT_TARGET_DIR="${PROJECT_TARGET_DIR:-${WORK_DIR:-/tmp}/target}"
-    KEYSTORE_PATH="${PROJECT_TARGET_DIR}/kc_keystore.pkcs12"
+    # Resolves "latest" and rebinds keystore.path under KEYCLOAK_INSTALL_DIR from config.
+    ensure_keycloak_install_dir_resolved
+
+    if [[ -z "${KEYCLOAK_INSTALL_DIR:-}" ]]; then
+        error "KEYCLOAK_INSTALL_DIR is not defined. Ensure configuration is loaded."
+    fi
+    if [[ -z "${KEYSTORE_PATH:-}" || "$KEYSTORE_PATH" != *"/data/"* ]]; then
+        error "keystore.path must be under .../data/<realm>/ (see config.yaml)."
+    fi
+
+    # Always write on the install tree (host setup / Dockerfile build), never a registration remap.
+    local data_rel="${KEYSTORE_PATH#*/data/}"
+    local realm_name ks_file
+    realm_name="$(dirname "$data_rel")"
+    ks_file="$(basename "$data_rel")"
+    [[ "$realm_name" == "." ]] && realm_name="${KEYCLOAK_REALM:-oid4vc-vci}"
+    export KEYSTORE_PATH="${KEYCLOAK_INSTALL_DIR}/data/${realm_name}/${ks_file}"
 
     if [[ -z "${SSL_TRUST_STORE:-}" ]]; then
         error "SSL_TRUST_STORE is not defined. Ensure configuration is loaded."
@@ -501,9 +525,7 @@ ensure_keycloak_crypto_materials() {
     fi
 
     ensure_directory_exists "$(dirname "$KEYSTORE_PATH")"
-    local keystore_basename
-    keystore_basename="$(basename "$KEYSTORE_PATH")"
-    local keystore_cache="$WORK_DIR/src/utils/crypto/$keystore_basename"
+    local keystore_cache="$WORK_DIR/src/utils/crypto/$ks_file"
 
     if [[ -f "$keystore_cache" ]]; then
         log "Reusing existing keystore $keystore_cache..."
@@ -514,6 +536,13 @@ ensure_keycloak_crypto_materials() {
         if [[ -f "$KEYSTORE_PATH" ]]; then
             cp "$KEYSTORE_PATH" "$keystore_cache"
         fi
+    fi
+
+    # Quay compose mounts ./target/keycloak-data → /opt/keycloak/data
+    local compose_keystore_path="${PROJECT_TARGET_DIR}/keycloak-data/${realm_name}/${ks_file}"
+    if [[ "$KEYSTORE_PATH" != "$compose_keystore_path" ]]; then
+        ensure_directory_exists "$(dirname "$compose_keystore_path")"
+        cp "$KEYSTORE_PATH" "$compose_keystore_path"
     fi
 }
 
@@ -546,6 +575,19 @@ ensure_keycloak_install_dir_resolved() {
         export KEYCLOAK_VERSION="$resolved_version"
         export KEYCLOAK_INSTALL_DIR="${PROJECT_TOOLS_DIR}/keycloak-${KEYCLOAK_VERSION}"
         export KEYCLOAK_TARBALL_PATH="${PROJECT_TARGET_DIR}/keycloak-${KEYCLOAK_VERSION}.tar.gz"
+    fi
+
+    # Keep config layout (.../data/<realm>/<file>) under the concrete install dir when the
+    # path is still workspace-relative. Do not rewrite HOST_WORK_DIR remaps (host abs paths
+    # outside WORK_DIR) or Docker /opt/keycloak registration paths.
+    if [[ -n "${KEYSTORE_PATH:-}" && -n "${KEYCLOAK_INSTALL_DIR:-}" \
+        && "$KEYSTORE_PATH" == *"/data/"* \
+        && "$KEYSTORE_PATH" != /opt/keycloak/* ]]; then
+        if [[ -n "${WORK_DIR:-}" && "$KEYSTORE_PATH" == "$WORK_DIR"* ]] \
+            || [[ "$KEYSTORE_PATH" == *"/keycloak-latest/"* ]] \
+            || [[ "$KEYSTORE_PATH" != /* ]]; then
+            export KEYSTORE_PATH="${KEYCLOAK_INSTALL_DIR}/data/${KEYSTORE_PATH#*/data/}"
+        fi
     fi
 }
 

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -177,41 +177,50 @@ export_yaml_as_env() {
         KEYCLOAK_FEATURES="$KEYCLOAK_FEATURES,oid4vc-vci-rest-credential-offer"
     export KEYCLOAK_FEATURES
 
-    # Resolve "latest" then keep keystore.path under the concrete install dir.
-    ensure_keycloak_install_dir_resolved
+    # Remap only — do not resolve "latest" here (that hits GitHub and would break
+    # compose down/stop offline). Resolve happens in init_script / crypto materials.
+    remap_keystore_path_for_runtime
+}
 
-    if [[ -n "${KEYSTORE_PATH:-}" && -n "${KEYCLOAK_INSTALL_DIR:-}" ]]; then
-        local docker_compose_cmd
-        docker_compose_cmd="$(detect_docker_compose 2>/dev/null || echo "")"
-        local keycloak_in_docker=false
-        local data_rel="${KEYSTORE_PATH#*/data/}"
+# -----------------------------------------------------------------------------
+# Remap KEYSTORE_PATH for where Keycloak runs (compose app vs CLI→host vs host).
+# Does not resolve KEYCLOAK_VERSION=latest / call the GitHub API.
+# -----------------------------------------------------------------------------
+remap_keystore_path_for_runtime() {
+    if [[ -z "${KEYSTORE_PATH:-}" || -z "${KEYCLOAK_INSTALL_DIR:-}" ]]; then
+        return 0
+    fi
 
-        if [[ -n "$docker_compose_cmd" ]]; then
-            if eval "$docker_compose_cmd" ps app --format json 2>/dev/null | grep -q '"State":"running"' 2>/dev/null || \
-                eval "$docker_compose_cmd" ps app 2>/dev/null | grep -q "app.*Up" 2>/dev/null; then
-                keycloak_in_docker=true
+    local docker_compose_cmd
+    docker_compose_cmd="$(detect_docker_compose 2>/dev/null || echo "")"
+    local keycloak_in_docker=false
+    local data_rel="${KEYSTORE_PATH#*/data/}"
+
+    if [[ -n "$docker_compose_cmd" ]]; then
+        if eval "$docker_compose_cmd" ps app --format json 2>/dev/null | grep -q '"State":"running"' 2>/dev/null || \
+            eval "$docker_compose_cmd" ps app 2>/dev/null | grep -q "app.*Up" 2>/dev/null; then
+            keycloak_in_docker=true
+        fi
+    fi
+
+    if [[ "$keycloak_in_docker" == "true" ]]; then
+        # Keycloak in docker: use container path
+        export KEYSTORE_PATH="/opt/keycloak/data/${data_rel}"
+    elif [[ -n "${KEYCLOAK_SSI_IN_CONTAINER:-}" ]]; then
+        # CLI in container, Keycloak on host: convert container path to host path
+        local host_project_root="${HOST_WORK_DIR:-}"
+        if [[ -z "$host_project_root" ]] && command -v docker &>/dev/null && [[ -S /var/run/docker.sock ]]; then
+            local container_name
+            container_name="$(hostname 2>/dev/null || echo "")"
+            if [[ -n "$container_name" ]]; then
+                host_project_root=$(docker inspect "$container_name" 2>/dev/null | \
+                    jq -r '.[0].Mounts[] | select(.Destination == "/workspace") | .Source' 2>/dev/null | head -1 || echo "")
             fi
         fi
-
-        if [[ "$keycloak_in_docker" == "true" ]]; then
-            # Keycloak in docker: use container path
-            export KEYSTORE_PATH="/opt/keycloak/data/${data_rel}"
-        elif [[ -n "${KEYCLOAK_SSI_IN_CONTAINER:-}" ]]; then
-            # CLI in container, Keycloak on host: convert container path to host path
-            local host_project_root="${HOST_WORK_DIR:-}"
-            if [[ -z "$host_project_root" ]] && command -v docker &>/dev/null && [[ -S /var/run/docker.sock ]]; then
-                local container_name
-                container_name="$(hostname 2>/dev/null || echo "")"
-                if [[ -n "$container_name" ]]; then
-                    host_project_root=$(docker inspect "$container_name" 2>/dev/null | \
-                        jq -r '.[0].Mounts[] | select(.Destination == "/workspace") | .Source' 2>/dev/null | head -1 || echo "")
-                fi
-            fi
-            if [[ -n "$host_project_root" && -n "${WORK_DIR:-}" && "$KEYSTORE_PATH" == "$WORK_DIR"* ]]; then
-                export KEYSTORE_PATH="${host_project_root}${KEYSTORE_PATH#"$WORK_DIR"}"
-            elif [[ -z "$host_project_root" ]]; then
-                warn "Cannot determine host path for KEYSTORE_PATH. Set HOST_WORK_DIR when running the CLI."
-            fi
+        if [[ -n "$host_project_root" && -n "${WORK_DIR:-}" && "$KEYSTORE_PATH" == "$WORK_DIR"* ]]; then
+            export KEYSTORE_PATH="${host_project_root}${KEYSTORE_PATH#"$WORK_DIR"}"
+        elif [[ -z "$host_project_root" ]]; then
+            warn "Cannot determine host path for KEYSTORE_PATH. Set HOST_WORK_DIR when running the CLI."
         fi
     fi
 }
@@ -629,6 +638,8 @@ init_script() {
     setup_environment
     # Resolve KEYCLOAK_VERSION \"latest\" to a concrete version and set KEYCLOAK_INSTALL_DIR/KEYCLOAK_TARBALL_PATH
     ensure_keycloak_install_dir_resolved
+    # Re-apply runtime remap after resolve so CLI→host config/import keep a host-visible path
+    remap_keystore_path_for_runtime
 
     # Log script start
     local script_name
@@ -646,4 +657,5 @@ init_script() {
 export -f log warn error success
 export -f setup_environment get_keycloak_pid stop_keycloak
 export -f urlencode detect_docker_compose init_script ensure_directory_exists check_dependencies export_yaml_as_env
+export -f remap_keystore_path_for_runtime
 export -f ensure_keycloak_crypto_materials get_latest_keycloak_version kcadm kc_truststore_path ensure_keycloak_install_dir_resolved


### PR DESCRIPTION
### Summary
- Store `kc_keystore.pkcs12` under `${KEYCLOAK_INSTALL_DIR}/data/<realm>/` to match Keycloak 26.6.4+ / 26.7.
- Update helper path resolution for host (`setup -d`) and Docker.
- Mount `./target/keycloak-data` to `/opt/keycloak/data` and copy the keystore there for compose.

### Test plan
- [x] `./keycloak-ssi.sh setup -d` on 26.7.0 — keystore under `target/tools/keycloak-26.7.0/data/oid4vc-vci/`
- [x] `./keycloak-ssi.sh setup -d` on main (`999.0.0-SNAPSHOT`)
- [x] `./keycloak-ssi.sh compose up -d` — keystore visible at `/opt/keycloak/data/oid4vc-vci/kc_keystore.pkcs12`
- [x] `./keycloak-ssi.sh config

Closes https://github.com/keycloak/keycloak-oauth-sig/issues/1038