### PR TITLE
Fix unreliable Keycloak stop on Ctrl+C

### DIFF
--- a/oid4vci-deployment/keycloak-ssi.sh
+++ b/oid4vci-deployment/keycloak-ssi.sh
@@ -502,7 +502,10 @@ main() {
 
 # Function to handle script exit and clean up
 cleanup() {
-    stop_keycloak
+    # Prevent re-entry if Ctrl+C is pressed again while stopping.
+    trap - SIGINT SIGTERM
+    stop_keycloak || true
+    exit 130
 }
 
 # Trap SIGINT (Ctrl+C) and SIGTERM signals

--- a/oid4vci-deployment/src/deployment/0.start-kc-oid4vci.sh
+++ b/oid4vci-deployment/src/deployment/0.start-kc-oid4vci.sh
@@ -79,17 +79,19 @@ log "Starting Keycloak with OID4VCI features..."
 
 cd "$KEYCLOAK_INSTALL_DIR" || error "Cannot cd to $KEYCLOAK_INSTALL_DIR"
 
+LOG_DIR="$WORK_DIR/target"
+ensure_directory_exists "$LOG_DIR"
+
 if [[ "$DETACH_MODE" == "true" ]]; then
-  LOG_DIR="$WORK_DIR/target"
-  ensure_directory_exists "$LOG_DIR"
   LOG_FILE="$LOG_DIR/keycloak.log"
   log "Detaching Keycloak; logs will be written to $LOG_FILE"
   KC_BOOTSTRAP_ADMIN_USERNAME="$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" KC_BOOTSTRAP_ADMIN_PASSWORD="$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD" \
   nohup bash -c "exec bin/kc.sh $START_COMMAND $DATABASE_OPTS --features=$KEYCLOAK_FEATURES" \
     >"$LOG_FILE" 2>&1 &
+  echo "$!" >> "$LOG_DIR/keycloak.pid"
   disown || true
 else
+  echo "$$" >> "$LOG_DIR/keycloak.pid"
   KC_BOOTSTRAP_ADMIN_USERNAME="$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" KC_BOOTSTRAP_ADMIN_PASSWORD="$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD" \
   exec bash -c "exec bin/kc.sh $START_COMMAND $DATABASE_OPTS --features=$KEYCLOAK_FEATURES"
-
 fi

--- a/oid4vci-deployment/src/utils/helper.sh
+++ b/oid4vci-deployment/src/utils/helper.sh
@@ -370,25 +370,46 @@ inject_environment_variables() {
 # -----------------------------------------------------------------------------
 # Keycloak Process Management
 # -----------------------------------------------------------------------------
+# Echo live Keycloak PID(s), one per line. Prefers target/keycloak.pid; otherwise
+# only matches processes tied to KEYCLOAK_INSTALL_DIR.
 get_keycloak_pid() {
-    local pid
-    if command -v pgrep &>/dev/null; then
-        pid=$(pgrep -f keycloak | head -n1 || true)
-    else
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            pid=$(ps aux | grep -i '[q]uarkus' | awk 'NR==1{print $2}' || true)
+    local pid=""
+    local install_dir="${KEYCLOAK_INSTALL_DIR:-}"
+    local pid_file="${WORK_DIR:-}/target/keycloak.pid"
+    local found=false
+
+    if [[ -f "$pid_file" ]]; then
+        local saved_pid
+        while IFS= read -r saved_pid || [[ -n "$saved_pid" ]]; do
+            [[ -z "$saved_pid" ]] && continue
+            if kill -0 "$saved_pid" 2>/dev/null; then
+                echo "$saved_pid"
+                found=true
+            fi
+        done < "$pid_file"
+        if [[ "$found" == "true" ]]; then
+            return 0
+        fi
+        rm -f "$pid_file" 2>/dev/null || true
+    fi
+
+    if [[ -n "$install_dir" ]]; then
+        if command -v pgrep &>/dev/null; then
+            pid=$(pgrep -f "${install_dir}/bin/kc\.sh|java.*${install_dir}" | head -n1 || true)
         else
-            pid=$(ps aux | grep -i '[k]eycloak' | awk 'NR==1{print $2}' || true)
+            pid=$(ps aux | grep -F "$install_dir" | grep -E '[k]c\.sh (start|start-dev)|java.*([K]eycloakMain|[Q]uarkusEntryPoint)' | awk 'NR==1{print $2}' || true)
         fi
     fi
-    echo "$pid"
+    [[ -n "$pid" ]] && echo "$pid"
 }
 
 stop_keycloak() {
     local keycloak_pid
-    keycloak_pid="$(get_keycloak_pid || true)"
+    local stopped=false
 
-    if [[ -n "$keycloak_pid" ]]; then
+    while IFS= read -r keycloak_pid || [[ -n "$keycloak_pid" ]]; do
+        [[ -z "$keycloak_pid" ]] && continue
+        stopped=true
         log "Keycloak instance found (PID: $keycloak_pid). Shutting it down..."
         if ! kill "$keycloak_pid"; then
             return 1
@@ -402,10 +423,16 @@ stop_keycloak() {
         if kill -0 "$keycloak_pid" 2>/dev/null; then
             return 1
         fi
+    done < <(get_keycloak_pid || true)
+
+    if [[ "$stopped" == "true" ]]; then
         log "Keycloak stopped."
     else
         log "No running Keycloak instance found."
     fi
+
+    # Clean up PID file
+    rm -f "${WORK_DIR:-}/target/keycloak.pid" 2>/dev/null || true
 
     # -------------------------------------------------------------------------
     # Stop and remove database container + volume using Docker Compose


### PR DESCRIPTION
### Summary
- Narrow `get_keycloak_pid` so it matches the Keycloak server (`kc.sh` / Keycloak JVM), not any process whose cmdline contains `keycloak`.
- Make the Ctrl+C cleanup trap one-shot so `stop_keycloak` cannot re-enter and spam shut-down logs.

### Test plan
- [x] `./keycloak-ssi.sh setup` (foreground), wait until Keycloak is up, press Ctrl+C
- [x] Keycloak stops cleanly; no repeating `Keycloak instance found... Shutting it down...`
- [x] CLI returns to the shell after one cleanup (DB down once)

Here is what I get after I press Ctrl+C to stop keycloak:
<img width="1053" height="707" alt="image" src="https://github.com/user-attachments/assets/c3bbc449-dfd0-45dd-92d9-9061fdc43c62" />

Closes https://github.com/keycloak/keycloak-oauth-sig/issues/1049
